### PR TITLE
Allow ComputerCraft to reconnect to the same session using a token

### DIFF
--- a/computercraft/sigils.lua
+++ b/computercraft/sigils.lua
@@ -73,6 +73,8 @@ local function init ()
   local wsContext = {
     wsUrl = config.server or DEFAULT_SERVER_URL,
     ws = nil,
+    reconnectToken = nil,
+    sessionId = string,
   }
 
   parallel.waitForAll(

--- a/computercraft/sigils/websocket.lua
+++ b/computercraft/sigils/websocket.lua
@@ -47,9 +47,9 @@ local function requestSessionOnce (wsContext)
     }
   end
 
-  ws.send(textutils.serializeJSON(req))
+  wsContext.ws.send(textutils.serializeJSON(req))
 
-  local res = ws.receive(5)
+  local res = wsContext.ws.receive(5)
   return textutils.unserializeJSON(res)
 end
 
@@ -88,15 +88,18 @@ local function connectAndRequestSession (wsContext, maxAttempts)
       return false
     end
     print('Trying to create session. Attempt', attempts)
+    os.sleep(3)
     res = requestSessionOnce(wsContext)
     attempts = attempts + 1
   end
+
+  print(textutils.serialiseJSON(res))
 
   print()
   print('Connection to editor server successful!')
   print('Press E again to end the session.')
   print('**')
-  print('** Insert code', res.sessionId, 'into web editor to edit pipes.')
+  print('** Insert code', wsContext.sessionId, 'into web editor to edit pipes.')
   print('**')
   return res.ccReconnectToken
 end

--- a/computercraft/sigils/websocket.lua
+++ b/computercraft/sigils/websocket.lua
@@ -24,27 +24,39 @@ local MESSAGE_TYPES = {
   GroupDel = true,
 }
 
----Request a session from the editor session server once
----@param ws Websocket ComputerCraft Websocket handle
+---Request a session from the editor session server once, or reconnect if
+---there's a reconnect token
+---@param wsContext table WebSocket context
 ---@return table response ConfirmationResponse as a Lua table
----@return string sessionId Session ID requested
-local function requestSessionOnce (ws)
-  local sessionId = Utils.randomString(4)
-  local req = {
-    type = 'SessionCreate',
-    reqId = Utils.randomString(20),
-    sessionId = sessionId,
-  }
+local function requestSessionOnce (wsContext)
+  local req
+
+  if wsContext.reconnectToken then
+    req = {
+      type = 'SessionRejoin',
+      reqId = Utils.randomString(20),
+      ccReconnectToken = reconnectToken,
+      sessionId = wsContext.sessionId,
+    }
+  else
+    wsContext.sessionId = Utils.randomString(4)
+    req = {
+      type = 'SessionCreate',
+      reqId = Utils.randomString(20),
+      sessionId = wsContext.sessionId,
+    }
+  end
+
   ws.send(textutils.serializeJSON(req))
 
   local res = ws.receive(5)
-  return textutils.unserializeJSON(res), sessionId
+  return textutils.unserializeJSON(res)
 end
 
 ---Connect to the editor session server and request a session, retrying if needed
 ---@param wsContext table Shared WebSocket context
 ---@param maxAttempts number Max attempts to connect and get a session
----@return boolean ok True if session was acquired, false otherwise
+---@return string ccReconnectToken A reconnect token for resuming the session if it breaks
 local function connectAndRequestSession (wsContext, maxAttempts)
   local attempts = 1
 
@@ -66,7 +78,7 @@ local function connectAndRequestSession (wsContext, maxAttempts)
   end
   wsContext.ws = ws
 
-  local res, sessionId = requestSessionOnce(ws)
+  local res = requestSessionOnce(wsContext)
   while res == nil or not res.ok do
     if attempts > maxAttempts then
       LOGGER:error(
@@ -76,7 +88,7 @@ local function connectAndRequestSession (wsContext, maxAttempts)
       return false
     end
     print('Trying to create session. Attempt', attempts)
-    res, sessionId = requestSessionOnce(ws)
+    res = requestSessionOnce(wsContext)
     attempts = attempts + 1
   end
 
@@ -84,9 +96,9 @@ local function connectAndRequestSession (wsContext, maxAttempts)
   print('Connection to editor server successful!')
   print('Press E again to end the session.')
   print('**')
-  print('** Insert code', sessionId, 'into web editor to edit pipes.')
+  print('** Insert code', res.sessionId, 'into web editor to edit pipes.')
   print('**')
-  return true
+  return res.ccReconnectToken
 end
 
 ---Queue an OS event for a given message. The event name will always be in the
@@ -120,14 +132,16 @@ local function doWebSocket (wsContext)
   print('Press E to create a factory editing session.')
   while true do
     if state == 'WAIT-FOR-USER' then
+      wsContext.reconnectToken = nil
       local event, char = os.pullEvent('char')
       if char == 'e' then
         state = 'START-CONNECT'
       end
     elseif state == 'START-CONNECT' then
-      local established = connectAndRequestSession(wsContext, 5)
-      if established then
+      local reconnectToken = connectAndRequestSession(wsContext, 5)
+      if reconnectToken then
         state = 'CONNECTED'
+        wsContext.reconnectToken = reconnectToken
       else
         print()
         print(
@@ -142,10 +156,19 @@ local function doWebSocket (wsContext)
         local ok, res, isBinary = pcall(function () return wsContext.ws.receive() end)
         if not ok then
           print()
-          print('Lost connection to editor session server.')
-          print('Press E to try to create a factory editing session again.')
-          wsContext.ws = nil
-          state = 'WAIT-FOR-USER'
+          print('Attempting to reconnect')
+          local reconnectToken = connectAndRequestSession(wsContext, 5)
+
+          if reconnectToken then
+            wsContext.reconnectToken = reconnectToken
+          else
+            print()
+            print('Lost connection to editor session server.')
+            print('Press E to try to create a factory editing session again.')
+            wsContext.ws = nil
+            state = 'WAIT-FOR-USER'
+          end
+
         elseif res ~= nil and not isBinary then
           queueEventFromMessage(textutils.unserializeJSON(res))
         end
@@ -158,6 +181,7 @@ local function doWebSocket (wsContext)
             'Editor session closed. Press E to create a new editing session ' ..
             'or press Q to stop all pipes and quit.'
           )
+          wsContext.reconnectToken = nil
           wsContext.ws.close()
           wsContext.ws = nil
           state = 'WAIT-FOR-USER'

--- a/computercraft/sigils/websocket.lua
+++ b/computercraft/sigils/websocket.lua
@@ -35,7 +35,7 @@ local function requestSessionOnce (wsContext)
     req = {
       type = 'SessionRejoin',
       reqId = Utils.randomString(20),
-      ccReconnectToken = reconnectToken,
+      ccReconnectToken = wsContext.reconnectToken,
       sessionId = wsContext.sessionId,
     }
   else
@@ -93,8 +93,6 @@ local function connectAndRequestSession (wsContext, maxAttempts)
     attempts = attempts + 1
   end
 
-  print(textutils.serialiseJSON(res))
-
   print()
   print('Connection to editor server successful!')
   print('Press E again to end the session.')
@@ -151,6 +149,7 @@ local function doWebSocket (wsContext)
           'Press E to try to create a factory editing session again ' ..
           'or press Q to stop all pipes and quit.'
         )
+        wsContext.reconnectToken = nil
         wsContext.ws = nil
         state = 'WAIT-FOR-USER'
       end
@@ -168,6 +167,7 @@ local function doWebSocket (wsContext)
             print()
             print('Lost connection to editor session server.')
             print('Press E to try to create a factory editing session again.')
+            wsContext.reconnectToken = nil
             wsContext.ws = nil
             state = 'WAIT-FOR-USER'
           end

--- a/computercraft/sigils/websocket.lua
+++ b/computercraft/sigils/websocket.lua
@@ -158,7 +158,7 @@ local function doWebSocket (wsContext)
         local ok, res, isBinary = pcall(function () return wsContext.ws.receive() end)
         if not ok then
           print()
-          print('Attempting to reconnect')
+          print('Lost connection to editor session server. Attempting to reconnect.')
           local reconnectToken = connectAndRequestSession(wsContext, 5)
 
           if reconnectToken then

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "uuid": "^9.0.1",
         "ws": "^8.16.0"
       },
       "devDependencies": {
@@ -3729,6 +3730,18 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
+    "uuid": "^9.0.1",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -195,7 +195,7 @@ function joinSession({ reqId, sessionId }: SessionJoinReq, editor: WebSocket): S
 }
 
 function rejoinSession({ reqId, sessionId, ccReconnectToken }: SessionRejoinReq, computerCraft: WebSocket) {
-  if (!sessions[reqId]) {
+  if (!sessions[sessionId]) {
     const res: FailResponse = {
       type: "ConfirmationResponse",
       respondingTo: "SessionRejoin",
@@ -208,7 +208,7 @@ function rejoinSession({ reqId, sessionId, ccReconnectToken }: SessionRejoinReq,
     return;
   }
 
-  if (sessions[reqId].ccReconnectToken !== ccReconnectToken) {
+  if (sessions[sessionId].ccReconnectToken !== ccReconnectToken) {
     const res: FailResponse = {
       type: "ConfirmationResponse",
       respondingTo: "SessionRejoin",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -122,6 +122,8 @@ function resetIdleTimer(session: Session) {
       session.editor.send(JSON.stringify(timeoutMsg));
       session.editor.close();
     }
+
+    delete sessions[session.id];
   }, 10 * 60 * 1000)
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -311,6 +311,8 @@ function queueRequestForCCForLater(request: Request, session: Session) {
       };
       session.editor.send(JSON.stringify(failResponse));
 
+      session.editorOutbox = [];
+
       session.editor.close();
     }, 10 * 1000);
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -223,6 +223,15 @@ function rejoinSession({ reqId, sessionId, ccReconnectToken }: SessionRejoinReq,
 
   sessions[sessionId].computerCraft = computerCraft;
 
+  const res: SessionCreateRes = {
+    type: "ConfirmationResponse",
+    respondingTo: "SessionRejoin",
+    ok: true,
+    reqId: reqId,
+    ccReconnectToken: ccReconnectToken,
+  };
+  computerCraft.send(JSON.stringify(res));
+
   return sessionId as SessionId;
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -238,6 +238,7 @@ function rejoinSession({ reqId, sessionId, ccReconnectToken }: SessionRejoinReq,
 
   if (session.staleOutboxTimerId) {
     clearTimeout(session.staleOutboxTimerId);
+    session.staleOutboxTimerId = undefined;
   }
 
   while (session.editorOutbox.length > 0) {

--- a/server/src/types/errors.ts
+++ b/server/src/types/errors.ts
@@ -3,5 +3,6 @@ export type ErrorType = (
   'PeerNotConnected' | // CC or editor peer tried to send a message to the other peer when the other peer is not connected
   'SessionIdNotExist' | // Editor tried connecting to a nonexistent session ID
   'SessionHasEditor' | // Editor tried connecting to a session ID that already has an editor
-  'SessionIdTaken' // CC tried requesting a new session using an ID that's already taken
+  'SessionIdTaken' | // CC tried requesting a new session using an ID that's already taken
+  'BadReconnectToken' // Reconnect token supplied is incorrect
 );

--- a/server/src/types/messages.ts
+++ b/server/src/types/messages.ts
@@ -15,7 +15,7 @@ export type MessageType = (
   "BatchRequest" |
   "ConfirmationResponse" |
   "IdleTimeout" |
-  "SessionCreate" | "SessionJoin" |
+  "SessionCreate" | "SessionJoin" | "SessionRejoin" |
   "FactoryGet" | "FactoryGetResponse" |
   FactoryUpdateRequest |
   "CcUpdatedFactory"
@@ -84,6 +84,10 @@ export interface SessionCreateReq extends Request {
   sessionId: SessionId,
 };
 
+export interface SessionCreateRes extends ConfirmationResponse {
+  ccReconnectToken: string,
+}
+
 /**
  * Request for joining an editor session via a session ID
  * 
@@ -92,6 +96,12 @@ export interface SessionCreateReq extends Request {
  */
 export interface SessionJoinReq extends Request {
   type: "SessionJoin",
+  sessionId: SessionId,
+}
+
+export interface SessionRejoinReq extends Request {
+  type: "SessionRejoin",
+  ccReconnectToken: string,
   sessionId: SessionId,
 }
 

--- a/server/src/types/session.ts
+++ b/server/src/types/session.ts
@@ -4,7 +4,8 @@ export type SessionId = string;
 
 export interface Session {
   id: SessionId,
-  computerCraft: WebSocket,
+  computerCraft?: WebSocket,
   editor?: WebSocket,
   idleTimerId?: ReturnType<typeof setTimeout>,
+  ccReconnectToken?: string,
 };

--- a/server/src/types/session.ts
+++ b/server/src/types/session.ts
@@ -1,11 +1,26 @@
 import { WebSocket } from "ws";
+import { Message } from "./messages";
 
 export type SessionId = string;
 
 export interface Session {
   id: SessionId,
+
   computerCraft?: WebSocket,
   editor?: WebSocket,
+
   idleTimerId?: ReturnType<typeof setTimeout>,
   ccReconnectToken?: string,
+
+  /**
+   * Messages from editor pending relay to CC. Used when CC disconnects
+   * unexpectedly.
+   */
+  editorOutbox: Message[],
+  /**
+   * If the editorOutbox gets populated after being empty, a timer is started
+   * which disconnects the editor if CC hasn't reconnected by the time the
+   * timer is reached
+   */
+  staleOutboxTimerId?: ReturnType<typeof setTimeout>,
 };


### PR DESCRIPTION
Previously if CC disconnects from the relay server, the editor gets disconnected and you have to manually start a new session, which is a huge problem if the connection between CC and the editor server is unstable.

Now if CC disconnects, it can reconnect using a session token created when it created the session. If the editor tries to send messages to CC while it's disconnected, CC has 10 seconds to reconnect before the editor is booted.