### PR TITLE
Sort layouted machines alphabetical by default

### DIFF
--- a/client/src/Layouting.ts
+++ b/client/src/Layouting.ts
@@ -53,7 +53,7 @@ export async function getLayoutedElements(nodes: Node[], edges: Edge[], factory:
   const graph: ElkNode = {
     id: "root",
     layoutOptions: elkOptions,
-    edges: edges.map(edge => ({ ...edge, sources: [edge.source], targets: [edge.target]})),
+    //edges: edges.map(edge => ({ ...edge, sources: [edge.source], targets: [edge.target]})),
     children: [],
   }
 


### PR DESCRIPTION
ELK behavior is stochastic, so to confuse users less, I tell it to position the machines in alphabetical order by default