### PR TITLE
fix collision and z-index problems

### DIFF
--- a/client/src/GraphUpdateCallbacks.ts
+++ b/client/src/GraphUpdateCallbacks.ts
@@ -105,13 +105,11 @@ function onNodeDrag(
     y: mouseEvent.clientY,
   });
 
-  // Get nodes that are under the mouse cursor AND are not the dragged node AND are compatible drop targets
-  // For the mouse checking, there's probably a dedicated function for it but I don't know what it is
   const intersections = getIntersectingNodes(boxToRect({
     x: mousePosition.x,
     x2: mousePosition.x+.1,
     y: mousePosition.y,
-    y2: mousePosition.y+.1
+    y2: mousePosition.y+50 // the 50 lets it detect the machine node's header (containing it name and attached peripherals) that's not technically part of the node
   }))
     .filter(node => node.id !== draggedNode.id && nodeIsCompatibleDropTarget(draggedNode, node));
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -64,30 +64,3 @@ body,
   height: 100%;
   margin: 0;
 }
-
-/* .react-flow__node {
-  z-index: -1 !important;
-} */
-
-/*
-  HACK: Slot groups need to appear above their parent machine,
-  and dragged machines should appear above other machines.
-  The problem is, there's no class added to child nodes (slot groups) if
-  the parent is being dragged.
-
-  This z-index stuff should probably be implemented in JS
-*/
-
-.react-flow__node.react-flow__node-machine {
-  z-index: -30 !important;
-}
-
-.react-flow__node.react-flow__node-slot-group {
-  z-index: -20 !important;
-}
-
-.react-flow__node.react-flow__node-machine.dragging {
-  z-index: -29 !important;
-}
-
-/* END HACK */


### PR DESCRIPTION
This PR fixes the bugs where the header of machines isn't detected during node-to-node drag and the z-index bugs.

Honestly not sure why the z-index bug is fixed, because all I did was remove the workaround I added because of the z-index bug in the first place. I think it has to do with the fact that the layouter unconditionally re-creates all the nodes after they change...