### PR TITLE
Implement editor ping-pong

### DIFF
--- a/client/src/components/NewSessionModal.tsx
+++ b/client/src/components/NewSessionModal.tsx
@@ -1,16 +1,17 @@
 import { SessionJoinReq } from "@server/types/messages";
 import { v4 as uuidv4 } from "uuid";
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { SendMessage } from "react-use-websocket";
 import logo from "../logo.png";
 import shackIndustries from "../shack-industries.png";
 
 export interface NewSessionModalData {
   sendMessage: SendMessage,
+  sessionId: string,
+  setSessionId: Dispatch<SetStateAction<string>>,
 };
 
-export function NewSessionModal({ sendMessage }: NewSessionModalData) {
-  const [ sessionId, setSessionId ] = useState("");
+export function NewSessionModal({ sendMessage, sessionId, setSessionId }: NewSessionModalData) {
 
   function joinSession() {
     const sessionJoinReq: SessionJoinReq = {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -64,3 +64,7 @@ body,
   height: 100%;
   margin: 0;
 }
+
+.react-flow__edges {
+  z-index: 100 !important;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,8 +16,20 @@ wss.on("connection", function connection(ws) {
   ws.on("error", console.error);
 
   ws.on("message", (data) => {
-    const json = data.toString();
-    const message = JSON.parse(json);
+    const messageData = data.toString();
+    
+    if (messageData === "ping") {
+      ws.send("pong");
+      return;
+    }
+
+    let message;
+    try {
+      message = JSON.parse(messageData);
+    } catch (e) {
+      console.error("Received bad message:", messageData);
+      return;
+    }
     console.log(message.type)
 
     const session = sessions[sessionId];
@@ -61,7 +73,7 @@ wss.on("connection", function connection(ws) {
             } else if (role === 'editor' && !session.computerCraft) {
               queueRequestForCCForLater(message as Request, session);
             } else {
-              relayMessage(json, sessionId, destination);
+              relayMessage(messageData, sessionId, destination);
             }
             break;
         }
@@ -76,7 +88,7 @@ wss.on("connection", function connection(ws) {
           };
           ws.send(JSON.stringify(res));
         } else {
-          relayMessage(json, sessionId, 'editor');
+          relayMessage(messageData, sessionId, 'editor');
         }
       }
     } catch (error) {


### PR DESCRIPTION
On the production server, if we don't ping-ping every 59 seconds or shorter interval, the server disconnects the client.

This implements the editor-server ping-pong, which is the most disruptive to the user.

Probably good to implement the cc-server ping-pong too, but the user probably wouldn't notice that.