### PR TITLE
Handle stale peripherals 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -196,7 +196,12 @@ export default function App() {
         }
       } else if (message.type === "CcUpdatedFactory") {
         const ccUpdatedFactory = message as CcUpdatedFactory;
-        patchFactory(ccUpdatedFactory.diff);
+        setReqsNeedingLayout({...reqsNeedingLayout, ["force-update-layout"]: true});
+        // HACK: setTimeout makes sure setReqsNeedingLayout happens before patchFactory.
+        // I have no idea why this is necessary, because the race condition doesn't happen
+        // when I need to update both states in other situations, like after receiving
+        // a FactoryUpdateRes
+        setTimeout(() => patchFactory(ccUpdatedFactory.diff), 100);
         return;
       } else if (message.type === "IdleTimeout") {
         const idleTimeout = message as IdleTimeout;
@@ -255,7 +260,10 @@ export default function App() {
           <MachineOptions sendMessage={ sendMessage } />
         </Panel>
         <Panel position="top-left">
-          <MissingPeriphs sendMessage={ sendMessage }/>
+          <MissingPeriphs
+            sendMessage={ sendMessage }
+            addReqNeedingLayout={addReqNeedingLayout}
+          />
         </Panel>
         <Background className="bg-neutral-700" />
         <MiniMap />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,8 +17,8 @@ import {
 
 import "reactflow/dist/style.css";
 
-import { edgeTypes, getEdgesForFactory, updateEdgesForFactory } from "./edges";
-import { getNodesForFactory, nodeTypes, updateNodesForFactory } from "./nodes";
+import { edgeTypes, getEdgesForFactory } from "./edges";
+import { getNodesForFactory, nodeTypes } from "./nodes";
 
 import { EdgeOptions } from "./components/EdgeOptions";
 import { NewSessionModal } from "./components/NewSessionModal";
@@ -51,7 +51,6 @@ export default function App() {
   const [ edges, setEdges, onEdgesChange ] = useEdgesState([]);
   const [ reactFlowInstance, setReactFlowInstance ] = useState(null as (ReactFlowInstance<any, any> | null));
 
-  const [ needLayout, setNeedLayout ] = useState(false);
   const [ tempEdge, setTempEdge ] = useState(null as (Edge | null));
 
   const { dropTarget, setDropTarget, clearDropTarget } = useDropTargetStore();
@@ -111,20 +110,15 @@ export default function App() {
   }, [readyState])
 
   useEffect(() => {
-    setNodes(getNodesForFactory(factory));
-    setEdges(getEdgesForFactory(factory));
-    setNeedLayout(true);
-  }, [factory, version]);
+    const nodes = getNodesForFactory(factory);
+    const edges = getEdgesForFactory(factory);
+    setEdges(edges);
 
-  useEffect(() => {
     (async () => {
-      if (needLayout) {
-        const layouted = await getLayoutedElements(nodes, edges, factory);
-        setNodes(layouted);
-        setNeedLayout(false);
-      }
+      const layouted = await getLayoutedElements(nodes, edges, factory);
+      setNodes(layouted);
     })();
-  }, [needLayout]);
+  }, [factory, version]);
 
   useEffect(() => {
     if (lastMessage !== null && typeof lastMessage.data === "string") {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -240,7 +240,6 @@ export default function App() {
       { showNewSessionModal && <NewSessionModal
           sendMessage={ sendMessage }
           addReqNeedingLayout={ addReqNeedingLayout }
-          sendMessage={ sendMessage }
           sessionId={sessionId}
           setSessionId={setSessionId}
         />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -88,8 +88,8 @@ export default function App() {
   );
 
   const onNodeDragStop: NodeDragHandler = useCallback(
-    (mouseEvent: MouseEvent, node: Node) => GraphUpdateCallbacks.onNodeDragStop(mouseEvent, node, dropTarget, clearDropTarget, sendMessage, reactFlowInstance, factory),
-    [setNodes, clearDropTarget, dropTarget, sendMessage, reactFlowInstance, factory]
+    (mouseEvent: MouseEvent, node: Node) => GraphUpdateCallbacks.onNodeDragStop(mouseEvent, node, dropTarget, clearDropTarget, sendMessage, reactFlowInstance, factory, addReqNeedingLayout),
+    [setNodes, clearDropTarget, dropTarget, sendMessage, reactFlowInstance, factory, addReqNeedingLayout]
   );
 
   const onDragOver: DragEventHandler = useCallback(
@@ -98,8 +98,8 @@ export default function App() {
   );
 
   const onDrop: DragEventHandler = useCallback(
-    (event: DragEvent) => GraphUpdateCallbacks.onDrop(event, reactFlowInstance, sendMessage, factory),
-    [reactFlowInstance, sendMessage, setNodes, factory]
+    (event: DragEvent) => GraphUpdateCallbacks.onDrop(event, reactFlowInstance, factory, sendMessage, addReqNeedingLayout),
+    [reactFlowInstance, factory, sendMessage, setNodes, addReqNeedingLayout]
   );
 
   const beforeNodesChange = useCallback(

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,6 +31,7 @@ import { TempEdgeOptions } from "./components/TempEdgeOptions";
 import { getLayoutedElements } from "./Layouting";
 import toast, { Toaster } from "react-hot-toast";
 import { Toast } from "./components/Toast";
+import { MissingPeriphs } from "./components/MissingPeriphs";
 
 const DEFAULT_ENDPOINT = (process.env.NODE_ENV === "production") ? "wss://sigils.fredchan.org" : "ws://localhost:3000";
 
@@ -241,6 +242,9 @@ export default function App() {
           <EdgeOptions sendMessage={ sendMessage } />
           <GroupOptions sendMessage={ sendMessage } />
           <MachineOptions sendMessage={ sendMessage } />
+        </Panel>
+        <Panel position="top-left">
+          <MissingPeriphs />
         </Panel>
         <Background className="bg-neutral-700" />
         <MiniMap />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -120,17 +120,6 @@ export default function App() {
     const edges = getEdgesForFactory(factory);
     setEdges(edges);
 
-    (async () => {
-      const layouted = await getLayoutedElements(nodes, edges, factory);
-      setNodes(layouted);
-    })();
-  }, [factory]);
-
-  useEffect(() => {
-    const nodes = getNodesForFactory(factory);
-    const edges = getEdgesForFactory(factory);
-    setEdges(edges);
-
     // determine if we need layout and remove requests from reqsNeedingLayout
     // that have been fulfilled
     let needLayout = false;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -171,7 +171,7 @@ export default function App() {
 
           if ("diff" in successRes) {
             const factoryUpdateRes = successRes as FactoryUpdateRes;
-            if (factoryUpdateRes.respondingTo in  reqsNeedingLayout) {
+            if (factoryUpdateRes.respondingTo in reqsNeedingLayout) {
               setReqsNeedingLayout({...reqsNeedingLayout, [factoryUpdateRes.reqId]: true});
             }
             patchFactory(factoryUpdateRes.diff);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -161,12 +161,16 @@ export default function App() {
 
           if (successRes.respondingTo === "FactoryGet") {
             const factoryGetRes = message as FactoryGetRes;
+            setReqsNeedingLayout({...reqsNeedingLayout, [factoryGetRes.reqId]: true});
             setFactory(factoryGetRes.factory);
             return;
           }
 
           if ("diff" in successRes) {
             const factoryUpdateRes = successRes as FactoryUpdateRes;
+            if (factoryUpdateRes.respondingTo in  reqsNeedingLayout) {
+              setReqsNeedingLayout({...reqsNeedingLayout, [factoryUpdateRes.reqId]: true});
+            }
             patchFactory(factoryUpdateRes.diff);
             return;
           }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -46,6 +46,12 @@ export default function App() {
 
   const { factory, version, setFactory, patchFactory } = useFactoryStore();
 
+  
+  // reqsNeedingLayout keys: Request IDs that, when fulfilled, should trigger graph layouting
+  // values: Boolean that's true if the Request has been fulfilled
+  type PendingRequests = {[requestId: string]: boolean};
+  const [ reqsNeedingLayout, setReqsNeedingLayout ] = useState({} as PendingRequests);
+
   const { getIntersectingNodes, getNode } = useReactFlow();
   const [ nodes, setNodes, onNodesChange ] = useNodesState([]);
   const [ edges, setEdges, onEdgesChange ] = useEdgesState([]);
@@ -114,10 +120,13 @@ export default function App() {
     const edges = getEdgesForFactory(factory);
     setEdges(edges);
 
-    (async () => {
-      const layouted = await getLayoutedElements(nodes, edges, factory);
-      setNodes(layouted);
-    })();
+    const needLayout = Object.values(reqsNeedingLayout).some(fulfilled => fulfilled);
+    if (needLayout) {
+      (async () => {
+        const layouted = await getLayoutedElements(nodes, edges, factory);
+        setNodes(layouted);
+      })();
+    }
   }, [factory, version]);
 
   useEffect(() => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -215,7 +215,11 @@ export default function App() {
     <div className="w-full h-full">
       <Toaster />
 
-      { showNewSessionModal && <NewSessionModal sendMessage={ sendMessage } /> }
+      { showNewSessionModal && <NewSessionModal
+         sendMessage={ sendMessage }
+         addReqNeedingLayout={ addReqNeedingLayout }
+        />
+      }
       { tempEdge && <TempEdgeOptions
           addReqNeedingLayout={ addReqNeedingLayout }
           sendMessage={ sendMessage }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -51,6 +51,9 @@ export default function App() {
   // values: Boolean that's true if the Request has been fulfilled
   type PendingRequests = {[requestId: string]: boolean};
   const [ reqsNeedingLayout, setReqsNeedingLayout ] = useState({} as PendingRequests);
+  const addReqNeedingLayout = useCallback((reqId: string) => {
+    setReqsNeedingLayout({...reqsNeedingLayout, [reqId]: true});
+  }, [reqsNeedingLayout, setReqsNeedingLayout]);
 
   const { getIntersectingNodes, getNode } = useReactFlow();
   const [ nodes, setNodes, onNodesChange ] = useNodesState([]);
@@ -70,13 +73,13 @@ export default function App() {
   );
 
   const onEdgesDelete: OnEdgesDelete = useCallback(
-    (edges) => GraphUpdateCallbacks.onEdgesDelete(edges, sendMessage),
-    [sendMessage]
+    (edges) => GraphUpdateCallbacks.onEdgesDelete(edges, sendMessage, addReqNeedingLayout),
+    [sendMessage, addReqNeedingLayout]
   );
 
   const onEdgeUpdate: OnEdgeUpdateFunc = useCallback(
-    (oldEdge, newConnection) => GraphUpdateCallbacks.onEdgeUpdate(oldEdge, newConnection, sendMessage, setEdges),
-    [sendMessage, setEdges]
+    (oldEdge, newConnection) => GraphUpdateCallbacks.onEdgeUpdate(oldEdge, newConnection, sendMessage, addReqNeedingLayout),
+    [sendMessage, setEdges, addReqNeedingLayout]
   );
 
   const onNodeDrag: NodeDragHandler = useCallback(
@@ -214,9 +217,10 @@ export default function App() {
 
       { showNewSessionModal && <NewSessionModal sendMessage={ sendMessage } /> }
       { tempEdge && <TempEdgeOptions
+          addReqNeedingLayout={ addReqNeedingLayout }
           sendMessage={ sendMessage }
-          tempEdge={ tempEdge }
           setTempEdge={ setTempEdge }
+          tempEdge={ tempEdge }
           onCancel={ () => {
             setTempEdge(null);
             setEdges(edges.filter(edge => edge.type !== "temp"));

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -244,7 +244,7 @@ export default function App() {
           <MachineOptions sendMessage={ sendMessage } />
         </Panel>
         <Panel position="top-left">
-          <MissingPeriphs />
+          <MissingPeriphs sendMessage={ sendMessage }/>
         </Panel>
         <Background className="bg-neutral-700" />
         <MiniMap />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -120,7 +120,30 @@ export default function App() {
     const edges = getEdgesForFactory(factory);
     setEdges(edges);
 
-    const needLayout = Object.values(reqsNeedingLayout).some(fulfilled => fulfilled);
+    (async () => {
+      const layouted = await getLayoutedElements(nodes, edges, factory);
+      setNodes(layouted);
+    })();
+  }, [factory]);
+
+  useEffect(() => {
+    const nodes = getNodesForFactory(factory);
+    const edges = getEdgesForFactory(factory);
+    setEdges(edges);
+
+    // determine if we need layout and remove requests from reqsNeedingLayout
+    // that have been fulfilled
+    let needLayout = false;
+    const unfulfilledReqs: PendingRequests = {};
+    for (let [req, fulfilled] of Object.entries(reqsNeedingLayout)) {
+      if (fulfilled) {
+        needLayout = true;
+      } else {
+        unfulfilledReqs[req] = false;
+      }
+    }
+    setReqsNeedingLayout(unfulfilledReqs);
+
     if (needLayout) {
       (async () => {
         const layouted = await getLayoutedElements(nodes, edges, factory);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,7 +44,7 @@ export default function App() {
   });
   const [ showNewSessionModal, setShowNewSessionModal ] = useState(true);
 
-  const { factory, addsAndDeletes, groupParents, setFactory, patchFactory } = useFactoryStore();
+  const { factory, version, setFactory, patchFactory } = useFactoryStore();
 
   const { getIntersectingNodes, getNode } = useReactFlow();
   const [ nodes, setNodes, onNodesChange ] = useNodesState([]);
@@ -114,23 +114,7 @@ export default function App() {
     setNodes(getNodesForFactory(factory));
     setEdges(getEdgesForFactory(factory));
     setNeedLayout(true);
-  }, [factory]);
-
-  useEffect(() => {
-    if (
-      addsAndDeletes.groups.adds.size > 0 ||
-      addsAndDeletes.groups.deletes.size > 0 ||
-      addsAndDeletes.machines.adds.size > 0 ||
-      addsAndDeletes.machines.deletes.size > 0
-    ) {
-      setNodes(nodes => updateNodesForFactory(nodes, addsAndDeletes, groupParents));
-      setNeedLayout(true);
-    }
-
-    if (addsAndDeletes.pipes.adds.size > 0 || addsAndDeletes.pipes.deletes.size > 0) {
-      setEdges(edges => updateEdgesForFactory(edges, factory, addsAndDeletes))
-    }
-  }, [addsAndDeletes]);
+  }, [factory, version]);
 
   useEffect(() => {
     (async () => {

--- a/client/src/GraphUpdateCallbacks.ts
+++ b/client/src/GraphUpdateCallbacks.ts
@@ -7,13 +7,19 @@ import { v4 as uuidv4 } from "uuid";
 import { CombineHandlers } from "./CombineHandlers";
 import { splitPeripheralFromMachine, splitSlotFromGroup } from "./SplitHandlers";
 
-function onEdgesDelete(edges: Edge[], sendMessage: SendMessage) {
+function onEdgesDelete(
+  edges: Edge[],
+  sendMessage: SendMessage,
+  addReqNeedingLayout: (reqId: string) => void
+) {
   for (let edge of edges) {
+    const reqId = uuidv4();
     const pipeDelReq: PipeDelReq = {
       type: "PipeDel",
-      reqId: uuidv4(),
+      reqId: reqId,
       pipeId: edge.id,
     };
+    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(pipeDelReq));
   }
 }
@@ -37,17 +43,25 @@ function onConnect(connection: Connection, setTempEdge: Dispatch<SetStateAction<
   setTempEdge(tempEdge);
 }
 
-function onEdgeUpdate(oldEdge: Edge, newConnection: Connection, sendMessage: SendMessage, setEdges: Dispatch<SetStateAction<Edge[]>>) {
+
+function onEdgeUpdate(
+  oldEdge: Edge,
+  newConnection: Connection,
+  sendMessage: SendMessage,
+  addReqNeedingLayout: (reqId: string) => void
+) {
   if (newConnection.source !== null && newConnection.target !== null) {
+    const reqId = uuidv4();
     const pipeEditReq: PipeEditReq = {
       type: "PipeEdit",
-      reqId: uuidv4(),
+      reqId: reqId,
       pipeId: oldEdge.id,
       edits: {
         from: newConnection.source,
         to: newConnection.target,
       }
     };
+    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(pipeEditReq));
   }
 }

--- a/client/src/GraphUpdateCallbacks.ts
+++ b/client/src/GraphUpdateCallbacks.ts
@@ -204,7 +204,6 @@ function onNodeDragStop(
       }
     }
 
-    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(nodeEditReq!));
   }
 }

--- a/client/src/GraphUpdateCallbacks.ts
+++ b/client/src/GraphUpdateCallbacks.ts
@@ -152,7 +152,8 @@ function onNodeDragStop(
   clearDropTarget: () => void,
   sendMessage: SendMessage,
   reactFlowInstance: (ReactFlowInstance | null),
-  factory: Factory
+  factory: Factory,
+  addReqNeedingLayout: (reqId: string) => void
 ) {
   if (!reactFlowInstance) return;
 
@@ -165,11 +166,13 @@ function onNodeDragStop(
     }
 
     if (messages) {
+      const reqId = uuidv4();
       const batchReq: BatchRequest = {
         type: "BatchRequest",
-        reqId: uuidv4(),
+        reqId: reqId,
         requests: messages,
       };
+      addReqNeedingLayout(reqId);
       sendMessage(JSON.stringify(batchReq));
     }
 
@@ -178,10 +181,11 @@ function onNodeDragStop(
     // update node x/y
 
     let nodeEditReq: MachineEditReq | GroupEditReq;
+    const reqId = uuidv4();
     if (draggedNode.type === "machine") {
       nodeEditReq = {
         type: "MachineEdit",
-        reqId: uuidv4(),
+        reqId: reqId,
         machineId: draggedNode.id,
         edits: {
           x: draggedNode.position.x,
@@ -191,7 +195,7 @@ function onNodeDragStop(
     } else if (draggedNode.type === "slot-group") {
       nodeEditReq = {
         type: "GroupEdit",
-        reqId: uuidv4(),
+        reqId: reqId,
         groupId: draggedNode.id,
         edits: {
           x: draggedNode.position.x,
@@ -200,6 +204,7 @@ function onNodeDragStop(
       }
     }
 
+    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(nodeEditReq!));
   }
 }
@@ -212,8 +217,9 @@ function onDragOver(event: DragEvent) {
 function onDrop(
   event: DragEvent,
   reactFlowInstance: (ReactFlowInstance | null),
+  factory: Factory,
   sendMessage: SendMessage,
-  factory: Factory
+  addReqNeedingLayout: (reqId: string) => void
 ) {
   event.preventDefault();
 
@@ -254,12 +260,13 @@ function onDrop(
   }
 
   if (requests && requests.length > 0) {
+    const reqId = uuidv4();
     const batchReq: BatchRequest = {
       type: "BatchRequest",
-      reqId: uuidv4(),
+      reqId: reqId,
       requests: requests,
     }
-
+    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(batchReq));
   }
 }

--- a/client/src/components/ItemSlot.tsx
+++ b/client/src/components/ItemSlot.tsx
@@ -2,6 +2,8 @@ import { GroupId, MachineId, Slot } from "@server/types/core-types";
 import { SIZES } from "../nodes/GroupNode";
 import { DragEvent } from "react";
 import { stringToColor } from "../StringToColor";
+import { useFactoryStore } from "../stores/factory";
+import { useShallow } from "zustand/react/shallow";
 
 export interface ItemSlotProps {
   slotIdx: number,
@@ -17,6 +19,8 @@ export interface ItemSlotDragData {
 }
 
 export function ItemSlot ({ slotIdx, slot, machineId, oldGroupId }: ItemSlotProps) {
+  const isMissing = useFactoryStore(useShallow(state => state.factory.missing[slot.periphId]));
+
   function onDragStart(event: DragEvent<HTMLDivElement>) {
     const dragData: ItemSlotDragData = {
       slot: slot,
@@ -32,7 +36,8 @@ export function ItemSlot ({ slotIdx, slot, machineId, oldGroupId }: ItemSlotProp
       draggable
       className={
         "nodrag absolute border w-[30px] h-[30px] flex items-center justify-center bg-mcgui-slot-bg hover:bg-blue-400 text-white hover:text-black" +
-        "border-2 border-b-mcgui-slot-border-light border-e-mcgui-slot-border-light border-t-mcgui-slot-border-dark border-s-mcgui-slot-border-dark "
+        "border-2 border-b-mcgui-slot-border-light border-e-mcgui-slot-border-light border-t-mcgui-slot-border-dark border-s-mcgui-slot-border-dark " +
+        (isMissing ? "opacity-30" : "")
       }
       style={{
         top: Math.floor(slotIdx / 9) * SIZES.slot + SIZES.slotContainerPadding + SIZES.paddingTop,

--- a/client/src/components/MissingPeripheralBadge.tsx
+++ b/client/src/components/MissingPeripheralBadge.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import { stringToColor } from "../StringToColor";
+
+export interface MissingPeripheralBadgeProps {
+  periphId: string,
+};
+
+export function MissingPeripheralBadge({ periphId }: MissingPeripheralBadgeProps) {
+  const [ hover, setHover ] = useState(false);
+
+  return (
+    <div
+      className="mcui-button text-sm h-8 text-white w-full flex justify-center items-center"
+      style={{
+        backgroundColor: hover ? "rgb(220 38 38)" : stringToColor(periphId)
+      }}
+      onMouseOver={ () => setHover(true) }
+      onMouseOut={ () => setHover(false) }
+    >
+      <span>{ hover ? "Remove" : periphId.split(":")[1] }</span>
+    </div>
+  );
+}

--- a/client/src/components/MissingPeriphs.tsx
+++ b/client/src/components/MissingPeriphs.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { SendMessage } from "react-use-websocket";
 import { v4 as uuidv4 } from "uuid";
 import { useFactoryStore } from "../stores/factory";
+import { MissingPeripheralBadge } from "./MissingPeripheralBadge";
 
 interface MissingPeriphsProps {
   sendMessage: SendMessage,
@@ -23,19 +24,26 @@ export function MissingPeriphs({ sendMessage }: MissingPeriphsProps) {
 
   return (
     <>
-      <ul>
-        {
-          Object.keys(missingPeriphs).map(periphId => 
-            <li
-              key={ periphId }
-              className="hover:bg-red-500"
-              onClick={ () => onDeletePeriph(periphId) }
-            >
-              { periphId }
-            </li>
-          )
-        }
-      </ul>
+      {Object.keys(missingPeriphs).length > 0 && <div className="border p-3 border-2 rounded mcui-window">
+        <header>
+          <h2>Missing peripherals</h2>
+          <span className="text-sm">Click to remove</span>
+        </header>
+
+        <ul>
+          {
+            Object.keys(missingPeriphs).map(periphId => 
+              <li
+                key={periphId}
+                onClick={ () => onDeletePeriph(periphId) }
+                className="w-full mt-2"
+              >
+                <MissingPeripheralBadge periphId={periphId}/>
+              </li>
+            )
+          }
+        </ul>
+      </div>}
     </>
   );
 }

--- a/client/src/components/MissingPeriphs.tsx
+++ b/client/src/components/MissingPeriphs.tsx
@@ -1,14 +1,38 @@
+import { PeriphId } from "@server/types/core-types";
+import { PeriphDel } from "@server/types/messages";
+import { useCallback } from "react";
+import { SendMessage } from "react-use-websocket";
+import { v4 as uuidv4 } from "uuid";
 import { useFactoryStore } from "../stores/factory";
 
-export function MissingPeriphs() {
+interface MissingPeriphsProps {
+  sendMessage: SendMessage,
+};
+
+export function MissingPeriphs({ sendMessage }: MissingPeriphsProps) {
   const missingPeriphs = useFactoryStore(state => state.factory.missing);
+
+  const onDeletePeriph = useCallback((periphId: PeriphId) => {
+    const periphDelReq: PeriphDel = {
+      type: "PeriphDel",
+      reqId: uuidv4(),
+      periphId: periphId,
+    };
+    sendMessage(JSON.stringify(periphDelReq));
+  }, [sendMessage]);
 
   return (
     <>
       <ul>
         {
           Object.keys(missingPeriphs).map(periphId => 
-            <li key={periphId}>{periphId}</li>
+            <li
+              key={ periphId }
+              className="hover:bg-red-500"
+              onClick={ () => onDeletePeriph(periphId) }
+            >
+              { periphId }
+            </li>
           )
         }
       </ul>

--- a/client/src/components/MissingPeriphs.tsx
+++ b/client/src/components/MissingPeriphs.tsx
@@ -1,0 +1,18 @@
+import { useFactoryStore } from "../stores/factory";
+
+export function MissingPeriphs() {
+  const missingPeriphs = useFactoryStore(state => state.factory.missing);
+  console.log(missingPeriphs);
+
+  return (
+    <>
+      <ul>
+        {
+          Object.keys(missingPeriphs).map(periphId => 
+            <li key={periphId}>{periphId}</li>
+          )
+        }
+      </ul>
+    </>
+  );
+}

--- a/client/src/components/MissingPeriphs.tsx
+++ b/client/src/components/MissingPeriphs.tsx
@@ -8,17 +8,21 @@ import { MissingPeripheralBadge } from "./MissingPeripheralBadge";
 
 interface MissingPeriphsProps {
   sendMessage: SendMessage,
+  addReqNeedingLayout: (reqId: string) => void,
 };
 
-export function MissingPeriphs({ sendMessage }: MissingPeriphsProps) {
+export function MissingPeriphs({ sendMessage, addReqNeedingLayout }: MissingPeriphsProps) {
   const missingPeriphs = useFactoryStore(state => state.factory.missing);
 
   const onDeletePeriph = useCallback((periphId: PeriphId) => {
+    const reqId = uuidv4();
     const periphDelReq: PeriphDel = {
       type: "PeriphDel",
-      reqId: uuidv4(),
+      reqId: reqId,
       periphId: periphId,
     };
+
+    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(periphDelReq));
   }, [sendMessage]);
 

--- a/client/src/components/MissingPeriphs.tsx
+++ b/client/src/components/MissingPeriphs.tsx
@@ -2,7 +2,6 @@ import { useFactoryStore } from "../stores/factory";
 
 export function MissingPeriphs() {
   const missingPeriphs = useFactoryStore(state => state.factory.missing);
-  console.log(missingPeriphs);
 
   return (
     <>

--- a/client/src/components/NewSessionModal.tsx
+++ b/client/src/components/NewSessionModal.tsx
@@ -13,8 +13,6 @@ export interface NewSessionModalData {
 };
 
 export function NewSessionModal({ sendMessage, sessionId, setSessionId, addReqNeedingLayout }: NewSessionModalData) {
-  const [ sessionId, setSessionId ] = useState("");
-
   function joinSession() {
     const reqId = uuidv4();
     const sessionJoinReq: SessionJoinReq = {

--- a/client/src/components/NewSessionModal.tsx
+++ b/client/src/components/NewSessionModal.tsx
@@ -7,17 +7,20 @@ import shackIndustries from "../shack-industries.png";
 
 export interface NewSessionModalData {
   sendMessage: SendMessage,
+  addReqNeedingLayout: (reqId: string) => void,
 };
 
-export function NewSessionModal({ sendMessage }: NewSessionModalData) {
+export function NewSessionModal({ sendMessage, addReqNeedingLayout }: NewSessionModalData) {
   const [ sessionId, setSessionId ] = useState("");
 
   function joinSession() {
+    const reqId = uuidv4();
     const sessionJoinReq: SessionJoinReq = {
       type: "SessionJoin",
-      reqId: uuidv4(),
+      reqId: reqId,
       sessionId: sessionId,
     };
+    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(sessionJoinReq));
   }
 

--- a/client/src/components/PeripheralBadge.tsx
+++ b/client/src/components/PeripheralBadge.tsx
@@ -1,6 +1,7 @@
 import { MachineId } from "@server/types/core-types";
 import { stringToColor } from "../StringToColor";
 import { DragEvent } from "react";
+import { useFactoryStore } from "../stores/factory";
 
 export interface PeripheralBadgeProps {
   periphId: string,
@@ -13,6 +14,8 @@ export interface PeripheralBadgeDragData {
 }
 
 export function PeripheralBadge({ periphId, machineId }: PeripheralBadgeProps) {
+  const missingPeriphs = useFactoryStore(state => state.factory.missing);
+
   function onDragStart(event: DragEvent<HTMLSpanElement>) {
     const dragData: PeripheralBadgeDragData = {
       periphId: periphId,
@@ -25,7 +28,10 @@ export function PeripheralBadge({ periphId, machineId }: PeripheralBadgeProps) {
   return (
     <span
       draggable
-      className="nodrag rounded py-0.5 px-2 text-xs me-1 bg-blue-500 text-white"
+      className={
+        "nodrag rounded py-0.5 px-2 text-xs me-1 bg-blue-500 text-white " +
+        (missingPeriphs[periphId] ? "opacity-30" : "")
+      }
       style={{
         backgroundColor: stringToColor(periphId)
       }}

--- a/client/src/components/TempEdgeOptions.tsx
+++ b/client/src/components/TempEdgeOptions.tsx
@@ -9,18 +9,20 @@ export interface TempEdgeOptionsProps {
   tempEdge: (Edge | null),
   setTempEdge: Dispatch<SetStateAction<Edge | null>>,
   onCancel: () => void,
+  addReqNeedingLayout: (reqId: string) => void,
 };
 
-export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }: TempEdgeOptionsProps) {
+export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel, addReqNeedingLayout }: TempEdgeOptionsProps) {
   const [ nickname, setNickname ] = useState("");
   const [ filter, setFilter ] = useState("");
 
   function onCommit() {
     if (!(tempEdge && tempEdge.source && tempEdge.target)) return;
 
+    const reqId = uuidv4();
     const pipeAddReq: PipeAddReq = {
       type: "PipeAdd",
-      reqId: uuidv4(),
+      reqId: reqId,
       pipe: {
         id: tempEdge.id,
         from: tempEdge.source,
@@ -31,6 +33,7 @@ export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }
     if (nickname !== "") pipeAddReq.pipe.nickname = nickname;
     if (filter !== "") pipeAddReq.pipe.filter = filter;
 
+    addReqNeedingLayout(reqId);
     setTempEdge(null);
     sendMessage(JSON.stringify(pipeAddReq));
   }

--- a/client/src/edges/index.ts
+++ b/client/src/edges/index.ts
@@ -1,7 +1,6 @@
 import { MarkerType, type Edge, type EdgeTypes } from "reactflow";
 import { Factory } from "@server/types/core-types";
 import { PipeEdge } from "./PipeEdge";
-import { FactoryAddsAndDeletes } from "../stores/factory";
 import { TempEdge } from "./TempEdge";
 
 export function getEdgesForFactory(factory: Factory): Edge[] {
@@ -17,35 +16,6 @@ export function getEdgesForFactory(factory: Factory): Edge[] {
       color: "magenta",
     }
   }));
-}
-
-function createAddedEdges(factory: Factory, addsAndDeletes: FactoryAddsAndDeletes) {
-  const newPipes = addsAndDeletes.pipes.adds;
-
-  const newEdges: Edge[] = [];
-
-  for (let pipeId of newPipes) {
-    const pipeEdge: Edge = {
-      id: pipeId,
-      type: "pipe",
-      source: factory.pipes[pipeId].from,
-      target: factory.pipes[pipeId].to,
-      markerEnd: {
-        type: MarkerType.Arrow,
-        width: 15,
-        height: 15,
-        color: "magenta"
-      }
-    };
-    newEdges.push(pipeEdge);
-  }
-
-  return newEdges;
-}
-
-export function updateEdgesForFactory(oldEdges: Edge[], factory: Factory, addsAndDeletes: FactoryAddsAndDeletes) {
-  const newEdges = oldEdges.filter(edge => !addsAndDeletes.pipes.deletes.has(edge.id) && edge.type !== "temp");
-  return newEdges.concat(createAddedEdges(factory, addsAndDeletes));
 }
 
 export const edgeTypes = {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -64,3 +64,7 @@ body,
   height: 100%;
   margin: 0;
 }
+
+.react-flow__edges {
+  z-index: 100 !important;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -66,5 +66,5 @@ body,
 }
 
 .react-flow__edges {
-  z-index: 100 !important;
+  z-index: 1001 !important;
 }

--- a/client/src/nodes/GroupNode.tsx
+++ b/client/src/nodes/GroupNode.tsx
@@ -36,7 +36,7 @@ export function GroupNode({ id, selected }: NodeProps) {
   // but for now we just detect if this Node is stale and render a placeholder
   if (slots === undefined) {
     return (
-      <div className="react-flow__node-default"></div>
+      <div className="react-flow__node-default hidden"></div>
     );
   }
   

--- a/client/src/nodes/MachineNode.tsx
+++ b/client/src/nodes/MachineNode.tsx
@@ -37,7 +37,7 @@ export function MachineNode({ id, selected }: NodeProps) {
   // Ideally we want the factory store and the nodes to get updated simultaneously,
   // but for now we just detect if this Node is stale and render a placeholder
   if (!exists) {
-    return <div className="react-flow__node-default"></div>
+    return <div className="react-flow__node-default hidden"></div>
   }
 
 

--- a/client/src/nodes/index.ts
+++ b/client/src/nodes/index.ts
@@ -2,7 +2,6 @@ import type { Node, NodeTypes } from "reactflow";
 import { Factory } from "@server/types/core-types";
 import { MachineNode } from "./MachineNode";
 import { GroupNode } from "./GroupNode";
-import { FactoryAddsAndDeletes, GroupParentsMap } from "../stores/factory";
 
 export function getNodesForFactory(factory: Factory): Node[] {
   const nodes = [];
@@ -32,51 +31,6 @@ export function getNodesForFactory(factory: Factory): Node[] {
   }
 
   return nodes;
-}
-
-export function createAddedNodes(addsAndDeletes: FactoryAddsAndDeletes, groupParents: GroupParentsMap) {
-  const newMachines = addsAndDeletes.machines.adds;
-  const newGroups = addsAndDeletes.groups.adds;
-
-  const newNodes: Node[] = [];
-
-  for (let machineId of newMachines) {
-    const machineNode: Node = {
-      id: machineId,
-      type: "machine",
-      position: { x: 0, y: 0 },
-      style: { width: 350, height: 300 },
-      data: {},
-    };
-    newNodes.push(machineNode);
-  }
-
-  for (let groupId of newGroups) {
-    const groupNode: Node = {
-      id: groupId,
-      type: "slot-group",
-      position: { x: 0, y: 0 },
-      parentId: groupParents[groupId],
-      extent: "parent",
-      data: {},
-    };
-    newNodes.push(groupNode)
-  }
-
-  return newNodes;
-}
-
-export function updateNodesForFactory(oldNodes: Node[], addsAndDeletes: FactoryAddsAndDeletes, groupParents: GroupParentsMap) {  
-  const newNodes = oldNodes
-    .filter(node => !addsAndDeletes.groups.deletes.has(node.id) && !addsAndDeletes.machines.deletes.has(node.id))
-    .map(node => {
-      if (node.type === "slot-group") {
-        return {...node, parentId: groupParents[node.id]}
-      }
-      return {...node};
-    }
-  );
-  return newNodes.concat(createAddedNodes(addsAndDeletes, groupParents));
 }
 
 export const nodeTypes = {

--- a/client/src/stores/factory.ts
+++ b/client/src/stores/factory.ts
@@ -28,6 +28,7 @@ const emptyFactory: Factory = {
   machines: {},
   pipes: {},
   groups: {},
+  missing: {},
 };
 
 const getEmptyFactoryAddsAndDeletes = (): FactoryAddsAndDeletes => ({

--- a/computercraft/sigils/controller.lua
+++ b/computercraft/sigils/controller.lua
@@ -61,6 +61,11 @@ local function handleGroupEdit (request, factory, sendMessage)
   return diff
 end
 
+local function handlePeriphDel(request, factory, sengMessage)
+  local diff = Factory.periphDel(factory, request.periphId)
+  return diff
+end
+
 local function createConfirmationResponse(request, ok, diff)
   return {
     type = 'ConfirmationResponse',
@@ -101,6 +106,7 @@ local function handlePeripheralDetach(periphId, factory, sendMessage)
   }))
 end
 
+
 local function listenForCcpipesEvents (wsContext, factory)
   while true do
     local sendMessage = function (...) end
@@ -120,6 +126,7 @@ local function listenForCcpipesEvents (wsContext, factory)
       ['ccpipes-GroupAdd'] = handleGroupAdd,
       ['ccpipes-GroupDel'] = handleGroupDel,
       ['ccpipes-GroupEdit'] = handleGroupEdit,
+      ['ccpipes-PeriphDel'] = handlePeriphDel,
     }
 
     if event == 'ccpipes-BatchRequest' then

--- a/computercraft/sigils/controller.lua
+++ b/computercraft/sigils/controller.lua
@@ -75,16 +75,24 @@ local function handlePeripheralAttach(periphId, factory, sendMessage)
   local periph = peripheral.wrap(periphId)
   local isInventory = periph['pushItems'] ~= nil
   if isInventory and periph.size() >= 1 then
-    local diff = Factory.periphAdd(factory, periphId)
-    sendMessage(textutils.serializeJSON({
-      type = "CcUpdatedFactory",
-      diff = diff
-    }))
+    if factory.missing[periphId] then
+      local diff = Factory.missingDel(factory, periphId)
+      sendMessage(textutils.serializeJSON({
+        type = "CcUpdatedFactory",
+        diff = diff
+      }))
+    else
+      local diff = Factory.periphAdd(factory, periphId)
+      sendMessage(textutils.serializeJSON({
+        type = "CcUpdatedFactory",
+        diff = diff
+      }))
+    end
   end
 end
 
 local function handlePeripheralDetach(periphId, factory, sendMessage)
-  local diff = Factory.periphDel(factory, periphId)
+  local diff = Factory.missingAdd(factory, periphId)
   if #diff == 0 then return end
 
   sendMessage(textutils.serializeJSON({

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -310,6 +310,7 @@ local function autodetectFactory ()
     machines = {},
     groups = {},
     pipes = {},
+    missing = {},
   }
   for i, periphId in ipairs(getPeripheralIds()) do
     local machine, groups = Machine.fromPeriphId(periphId)

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -387,6 +387,13 @@ local function updateWithPeriphChanges (factory)
       periphAdd(factory, currentPeriphId)
     end
   end
+
+  -- remove peripherals from missing peripheral list are connected now
+  for periphId, _ in pairs(factory.missing) do
+    if currentPeriphSet[periphId] then
+      missingDel(factory, periphId)
+    end
+  end
 end
 
 return {

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -324,8 +324,8 @@ local function autodetectFactory ()
   return factory
 end
 
----Given an existing factory, remove peripherals that are no longer on the
----network and create machines for newly added peripherals.
+---Given an existing factory, add peripherals that are no longer on the network
+---to the missing peripheral set and create machines for newly added peripherals.
 ---@param factory Factory Factory to update with peripheral changes
 local function updateWithPeriphChanges (factory)
   local currentPeriphSet = {}
@@ -340,11 +340,11 @@ local function updateWithPeriphChanges (factory)
     end
   end
 
-  -- get rid of disconnected peripherals:
-  -- remove anything in oldPeriphSet that's not in currentPeriphSet
+  -- put disconnected peripherals in missing:
+  -- (any periphId in oldPeriphSet that's not in currentPeriphSet goes into missing)
   for oldPeriphId, _ in pairs(oldPeriphSet) do
     if currentPeriphSet[oldPeriphId] == nil then
-      periphDel(factory, oldPeriphId)
+      factory.missing[oldPeriphId] = true
     end
   end
 

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -289,6 +289,38 @@ local function periphDel (factory, periphId)
   return Utils.concatArrays(unpack(diffs))
 end
 
+---Add a peripheral to the missing peripherals set
+---@param factory Factory Factory to add to
+---@param periphId string CC Peripheral ID
+---@return table diffs List of jsondiffpatch Deltas for the factory
+local function missingAdd (factory, periphId)
+  factory.missing[periphId] = true
+
+  local diff = {
+    missing = {
+      [periphId] = {true}
+    }
+  }
+  return {diff}
+end
+
+---Delete a peripheral from the missing peripherals set
+---@param factory Factory Factory to delete from to
+---@param periphId string CC Peripheral ID
+---@return table diffs List of jsondiffpatch Deltas for the factory
+local function missingDel (factory, periphId)
+  factory.missing[periphId] = nil
+
+  local diff = {
+    missing = {
+      [periphId] = {
+        nil, 0, 0
+      }
+    }
+  }
+  return {diff}
+end
+
 ---Get peripheral IDs connected to this factory
 ---@return string[] periphs List of peripheral IDs
 local function getPeripheralIds ()

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -401,6 +401,8 @@ return {
   groupEdit = groupEdit,
   periphAdd = periphAdd,
   periphDel = periphDel,
+  missingAdd = missingAdd,
+  missingDel = missingDel,
   autodetectFactory = autodetectFactory,
   updateWithPeriphChanges = updateWithPeriphChanges,
   saveFactory = saveFactory,

--- a/computercraft/sigils/pipe.lua
+++ b/computercraft/sigils/pipe.lua
@@ -8,11 +8,11 @@ local TransferCalculator = require('sigils.transfer-calculator')
 local Filter = require('sigils.filter')
 local LOGGER = require('sigils.logging').LOGGER
 
-local function processPipe (pipe, groupMap)
+local function processPipe (pipe, groupMap, missingPeriphs)
   local filter = Filter.getFilterFn(pipe.filter)
   local ok, transferOrders = pcall(
     function ()
-      return TransferCalculator.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], filter)
+      return TransferCalculator.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], missingPeriphs, filter)
     end
   )
 
@@ -35,7 +35,7 @@ end
 
 local function processAllPipes (factory)
   for pipeId, pipe in pairs(factory.pipes) do
-    processPipe(pipe, factory.groups)
+    processPipe(pipe, factory.groups, factory.missing)
   end
 end
 

--- a/computercraft/sigils/websocket.lua
+++ b/computercraft/sigils/websocket.lua
@@ -22,6 +22,7 @@ local MESSAGE_TYPES = {
   GroupAdd = true,
   GroupEdit = true,
   GroupDel = true,
+  PeriphDel = true
 }
 
 ---Request a session from the editor session server once, or reconnect if

--- a/server/src/types/core-types.ts
+++ b/server/src/types/core-types.ts
@@ -22,7 +22,7 @@ export interface Factory {
     pipes: PipeMap,
     machines: MachineMap,
     groups: GroupMap,
-    missing: PeriphId[],
+    missing: MissingPeriphMap,
 }
 
 export type PipeId = string;
@@ -40,6 +40,11 @@ export interface Pipe {
 };
 
 export type PeriphId = string;
+
+/**
+ * A Lua-style set of Peripheral IDs missing from the CC network
+ */
+export type MissingPeriphMap = { [key: PeriphId]: boolean }
 
 /**
  * Data structure representing a slot on a particular peripheral

--- a/server/src/types/core-types.ts
+++ b/server/src/types/core-types.ts
@@ -15,11 +15,14 @@
  * - Each machine has one or more slot Groups, which group together the
  * peripherals' slots so they're collectively addressable.
  * - Pipes connect Groups together to transfer items between them.
+ * - Missing peripherals are peripherals that may be part of some Machine(s) but
+ *   are disconnected from the network
  */
 export interface Factory {
     pipes: PipeMap,
     machines: MachineMap,
     groups: GroupMap,
+    missing: PeriphId[],
 }
 
 export type PipeId = string;
@@ -36,11 +39,13 @@ export interface Pipe {
     filter?: string,
 };
 
+export type PeriphId = string;
+
 /**
  * Data structure representing a slot on a particular peripheral
  */
 export interface Slot {
-    periphId: string,
+    periphId: PeriphId,
     slot: number,
 };
 

--- a/server/src/types/messages.ts
+++ b/server/src/types/messages.ts
@@ -1,4 +1,4 @@
-import { Factory, Group, GroupId, Machine, MachineId, Pipe, PipeId } from "./core-types"
+import { Factory, Group, GroupId, Machine, MachineId, PeriphId, Pipe, PipeId } from "./core-types"
 import { ErrorType } from "./errors";
 import { SessionId } from "./session";
 import { Delta } from "jsondiffpatch";
@@ -6,7 +6,8 @@ import { Delta } from "jsondiffpatch";
 export const FACTORY_UPDATE_REQUEST_TYPES = [
   "PipeAdd", "PipeEdit", "PipeDel",
   "MachineAdd", "MachineEdit", "MachineDel",
-  "GroupAdd", "GroupEdit", "GroupDel"
+  "GroupAdd", "GroupEdit", "GroupDel",
+  "PeriphDel",
 ] as const;
 
 export type FactoryUpdateRequest = typeof FACTORY_UPDATE_REQUEST_TYPES[number];
@@ -234,6 +235,16 @@ export interface GroupAddReq extends Request {
   type: "GroupAdd",
   group: Group,
   machineId: MachineId,
+}
+
+/**
+ * Request to delete a peripheral from the factory.
+ * 
+ * - Emitted from the editor when the user wants to delete a missing peripheral
+ */
+export interface PeriphDel extends Request {
+  type: "PeriphDel",
+  periphId: PeriphId,
 }
 
 /**


### PR DESCRIPTION
This PR makes it so if a peripheral gets disconnected from the CC network, it's not deleted right away. Instead, it's marked as missing, and the user needs to manually delete it.

This makes SIGILS work better when chunks get unloaded, so that if a peripheral disappears the factory doesn't just get destroyed.

This also changes how the client figures out when to re-layout. Instead of trying to detect node and edge adds/deletes from the JSON diffs, it will remember the request IDs of requests that need a layout change once CC responds to it. When it receives the response, a layout is triggered.