### PR TITLE
Add available periphs feature

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,7 @@ import toast, { Toaster } from "react-hot-toast";
 import { Toast } from "./components/Toast";
 import { MissingPeriphs } from "./components/MissingPeriphs";
 import { Attribution } from "./components/Attribution";
+import { AvailablePeriphs } from "./components/AvailablePeriphs";
 
 const DEFAULT_ENDPOINT = (process.env.NODE_ENV === "production") ? "wss://sigils.fredchan.org" : "ws://localhost:3000";
 
@@ -291,6 +292,7 @@ export default function App() {
             sendMessage={ sendMessage }
             addReqNeedingLayout={addReqNeedingLayout}
           />
+          <AvailablePeriphs />
         </Panel>
         <Panel position="bottom-left" className="ms-16"><Attribution/></Panel>
         <Background className="bg-neutral-700" />

--- a/client/src/GraphUpdateCallbacks.ts
+++ b/client/src/GraphUpdateCallbacks.ts
@@ -276,7 +276,7 @@ function onDrop(
     x: mousePosition.x,
     x2: mousePosition.x+.1,
     y: mousePosition.y,
-    y2: mousePosition.y+.1
+    y2: mousePosition.y+50
   }));
 
   const slotData = event.dataTransfer.getData("application/ccpipes-slotmove");
@@ -321,6 +321,10 @@ function onDrop(
       type: "PeriphAdd",
       reqId: reqId,
       periphId: periphId,
+      options: {
+        x: mousePosition.x,
+        y: mousePosition.y+50,
+      }
     }
     addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(periphAddReq));

--- a/client/src/GraphUpdateCallbacks.ts
+++ b/client/src/GraphUpdateCallbacks.ts
@@ -1,11 +1,12 @@
 import { Factory, Group, GroupId, Machine, MachineId, Pipe, PipeId } from "@server/types/core-types";
-import { BatchRequest, GroupEditReq, MachineEditReq, PipeDelReq, PipeEditReq, Request } from "@server/types/messages";
+import { BatchRequest, GroupEditReq, MachineEditReq, PeriphAddReq, PipeDelReq, PipeEditReq, Request } from "@server/types/messages";
 import { Dispatch, DragEvent, MouseEvent, SetStateAction } from "react";
 import { SendMessage } from "react-use-websocket/dist/lib/types";
 import { boxToRect, Connection, Edge, Instance, MarkerType, Node, ReactFlowInstance } from "reactflow";
 import { v4 as uuidv4 } from "uuid";
 import { CombineHandlers } from "./CombineHandlers";
 import { splitPeripheralFromMachine, splitSlotFromGroup } from "./SplitHandlers";
+import { AvailablePeripheralBadgeDragData } from "./components/AvailablePeripheralBadge";
 
 function onEdgesDelete(
   edges: Edge[],
@@ -279,7 +280,6 @@ function onDrop(
   }));
 
   const slotData = event.dataTransfer.getData("application/ccpipes-slotmove");
-
   if (slotData) {
     const { machineId } = JSON.parse(slotData);
     const parentMachine = reactFlowInstance.getNode(machineId);
@@ -292,10 +292,10 @@ function onDrop(
     );
   }
 
-  const peripheralData = event.dataTransfer.getData("application/ccpipes-peripheralmove");
-  if (peripheralData) {
+  const peripheralMoveData = event.dataTransfer.getData("application/ccpipes-peripheralmove");
+  if (peripheralMoveData) {
     requests = splitPeripheralFromMachine(
-      JSON.parse(peripheralData),
+      JSON.parse(peripheralMoveData),
       intersections,
       factory,
       mousePosition
@@ -311,6 +311,19 @@ function onDrop(
     }
     addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(batchReq));
+  }
+
+  const peripheralAddData = event.dataTransfer.getData("application/ccpipes-peripheraladd");
+  if (peripheralAddData) {
+    const { periphId } = JSON.parse(peripheralAddData) as AvailablePeripheralBadgeDragData;
+    const reqId = uuidv4();
+    const periphAddReq: PeriphAddReq = {
+      type: "PeriphAdd",
+      reqId: reqId,
+      periphId: periphId,
+    }
+    addReqNeedingLayout(reqId);
+    sendMessage(JSON.stringify(periphAddReq));
   }
 }
 

--- a/client/src/components/AvailablePeripheralBadge.tsx
+++ b/client/src/components/AvailablePeripheralBadge.tsx
@@ -1,0 +1,37 @@
+import { stringToColor } from "../StringToColor";
+import { DragEvent } from "react";
+import { useFactoryStore } from "../stores/factory";
+
+export interface AvailablePeripheralBadgeProps {
+  periphId: string,
+};
+
+export interface AvailablePeripheralBadgeDragData {
+  periphId: string,
+}
+
+export function AvailablePeripheralBadge({ periphId }: AvailablePeripheralBadgeProps) {
+  const missingPeriphs = useFactoryStore(state => state.factory.missing);
+
+  function onDragStart(event: DragEvent<HTMLSpanElement>) {
+    const dragData: AvailablePeripheralBadgeDragData = {periphId: periphId};
+    event.dataTransfer.setData("application/ccpipes-peripheraladd", JSON.stringify(dragData));
+    event.dataTransfer.effectAllowed = "move";
+  }
+
+  return (
+    <span
+      draggable
+      className={
+        "nodrag rounded py-0.5 px-2 text-xs me-1 bg-blue-500 text-white " +
+        (missingPeriphs[periphId] ? "opacity-30" : "")
+      }
+      style={{
+        backgroundColor: stringToColor(periphId)
+      }}
+      onDragStart={ onDragStart }
+    >
+      { periphId.split(":")[1] }
+    </span>
+  );
+}

--- a/client/src/components/AvailablePeripheralBadge.tsx
+++ b/client/src/components/AvailablePeripheralBadge.tsx
@@ -24,6 +24,7 @@ export function AvailablePeripheralBadge({ periphId }: AvailablePeripheralBadgeP
       draggable
       className={
         "nodrag rounded py-0.5 px-2 text-xs me-1 bg-blue-500 text-white " +
+        "relative hover:-top-0.5 hover:shadow-md " +
         (missingPeriphs[periphId] ? "opacity-30" : "")
       }
       style={{

--- a/client/src/components/AvailablePeripheralBadge.tsx
+++ b/client/src/components/AvailablePeripheralBadge.tsx
@@ -24,7 +24,7 @@ export function AvailablePeripheralBadge({ periphId }: AvailablePeripheralBadgeP
       draggable
       className={
         "nodrag rounded py-0.5 px-2 text-xs me-1 bg-blue-500 text-white " +
-        "relative hover:-top-0.5 hover:shadow-md " +
+        "relative hover:-top-0.5 hover:shadow " +
         (missingPeriphs[periphId] ? "opacity-30" : "")
       }
       style={{

--- a/client/src/components/AvailablePeriphs.tsx
+++ b/client/src/components/AvailablePeriphs.tsx
@@ -1,0 +1,31 @@
+import { useFactoryStore } from "../stores/factory";
+import { AvailablePeripheralBadge } from "./AvailablePeripheralBadge";
+
+export function AvailablePeriphs() {
+  const availablePeriphs = useFactoryStore(state => state.factory.available);
+
+  return (
+    <>
+      {Object.keys(availablePeriphs).length > 0 && <div className="border p-3 border-2 rounded mcui-window">
+        <header>
+          <h2>Missing peripherals</h2>
+          <span className="text-sm">Click to remove</span>
+        </header>
+
+        <ul>
+          {
+            Object.keys(availablePeriphs).map(periphId => 
+              <li
+                key={periphId}
+                draggable
+                className="nodrag w-full mt-2"
+              >
+                <AvailablePeripheralBadge periphId={ periphId } />
+              </li>
+            )
+          }
+        </ul>
+      </div>}
+    </>
+  );
+}

--- a/client/src/components/AvailablePeriphs.tsx
+++ b/client/src/components/AvailablePeriphs.tsx
@@ -8,8 +8,8 @@ export function AvailablePeriphs() {
     <>
       {Object.keys(availablePeriphs).length > 0 && <div className="border p-3 border-2 rounded mcui-window">
         <header>
-          <h2>Missing peripherals</h2>
-          <span className="text-sm">Click to remove</span>
+          <h2>Available peripherals</h2>
+          <span className="text-sm">Drag into factory to add</span>
         </header>
 
         <ul>
@@ -18,7 +18,7 @@ export function AvailablePeriphs() {
               <li
                 key={periphId}
                 draggable
-                className="nodrag w-full mt-2"
+                className="nodrag w-full mt-2 cursor-pointer hover:-top-0.5 relative"
               >
                 <AvailablePeripheralBadge periphId={ periphId } />
               </li>

--- a/client/src/components/AvailablePeriphs.tsx
+++ b/client/src/components/AvailablePeriphs.tsx
@@ -6,19 +6,19 @@ export function AvailablePeriphs() {
 
   return (
     <>
-      {Object.keys(availablePeriphs).length > 0 && <div className="border p-3 border-2 rounded mcui-window">
+      {Object.keys(availablePeriphs).length > 0 && <div className="border p-3 border-2 rounded mcui-window flex flex-col items-center">
         <header>
           <h2>Available peripherals</h2>
           <span className="text-sm">Drag into factory to add</span>
         </header>
 
-        <ul>
+        <ul className="flex w-48 flex-wrap gap-2 mt-3 justify-around">
           {
             Object.keys(availablePeriphs).map(periphId => 
               <li
                 key={periphId}
                 draggable
-                className="nodrag w-full mt-2 cursor-pointer hover:-top-0.5 relative"
+                className="nodrag w-full mt-2 cursor-pointer inline-block contents"
               >
                 <AvailablePeripheralBadge periphId={ periphId } />
               </li>

--- a/client/src/components/MissingPeriphs.tsx
+++ b/client/src/components/MissingPeriphs.tsx
@@ -28,7 +28,7 @@ export function MissingPeriphs({ sendMessage, addReqNeedingLayout }: MissingPeri
 
   return (
     <>
-      {Object.keys(missingPeriphs).length > 0 && <div className="border p-3 border-2 rounded mcui-window">
+      {Object.keys(missingPeriphs).length > 0 && <div className="border p-3 border-2 rounded mcui-window mb-3">
         <header>
           <h2>Missing peripherals</h2>
           <span className="text-sm">Click to remove</span>

--- a/client/src/components/MissingPeriphs.tsx
+++ b/client/src/components/MissingPeriphs.tsx
@@ -1,5 +1,5 @@
 import { PeriphId } from "@server/types/core-types";
-import { PeriphDel } from "@server/types/messages";
+import { PeriphDelReq } from "@server/types/messages";
 import { useCallback } from "react";
 import { SendMessage } from "react-use-websocket";
 import { v4 as uuidv4 } from "uuid";
@@ -16,7 +16,7 @@ export function MissingPeriphs({ sendMessage, addReqNeedingLayout }: MissingPeri
 
   const onDeletePeriph = useCallback((periphId: PeriphId) => {
     const reqId = uuidv4();
-    const periphDelReq: PeriphDel = {
+    const periphDelReq: PeriphDelReq = {
       type: "PeriphDel",
       reqId: reqId,
       periphId: periphId,

--- a/client/src/components/PeripheralBadge.tsx
+++ b/client/src/components/PeripheralBadge.tsx
@@ -30,6 +30,7 @@ export function PeripheralBadge({ periphId, machineId }: PeripheralBadgeProps) {
       draggable
       className={
         "nodrag rounded py-0.5 px-2 text-xs me-1 bg-blue-500 text-white " +
+        "relative hover:-top-0.5 hover:shadow " +
         (missingPeriphs[periphId] ? "opacity-30" : "")
       }
       style={{

--- a/client/src/stores/factory.ts
+++ b/client/src/stores/factory.ts
@@ -18,6 +18,7 @@ const emptyFactory: Factory = {
   pipes: {},
   groups: {},
   missing: {},
+  available: {},
 };
 
 export interface GroupParentsMap {

--- a/computercraft/sigils.lua
+++ b/computercraft/sigils.lua
@@ -47,7 +47,7 @@ local function init ()
   print("Welcome to SIGILS! Press Q to stop all pipes and quit.\n")
 
   local config = getConfig()
-  Logging.LOGGER:setLevel(config.logLevel or 1)
+  Logging.LOGGER:setLevel(config.logLevel or Logging.LEVELS.ERROR)
 
   -- try to load the factory
   local factoryJsonFile = io.open(Utils.absolutePathTo('factory.json'), 'r')

--- a/computercraft/sigils/controller.lua
+++ b/computercraft/sigils/controller.lua
@@ -62,7 +62,7 @@ local function handleGroupEdit (request, factory, sendMessage)
 end
 
 local function handlePeriphAdd(request, factory, sendMessage)
-  local diff = Factory.periphAdd(factory, request.periphId)
+  local diff = Factory.periphAdd(factory, request.periphId, request.options)
   return diff
 end
 

--- a/computercraft/sigils/controller.lua
+++ b/computercraft/sigils/controller.lua
@@ -61,6 +61,11 @@ local function handleGroupEdit (request, factory, sendMessage)
   return diff
 end
 
+local function handlePeriphAdd(request, factory, sendMessage)
+  local diff = Factory.periphAdd(factory, request.periphId)
+  return diff
+end
+
 local function handlePeriphDel(request, factory, sengMessage)
   local diff = Factory.periphDel(factory, request.periphId)
   return diff
@@ -124,6 +129,7 @@ local function listenForCcpipesEvents (wsContext, factory)
       ['ccpipes-GroupAdd'] = handleGroupAdd,
       ['ccpipes-GroupDel'] = handleGroupDel,
       ['ccpipes-GroupEdit'] = handleGroupEdit,
+      ['ccpipes-PeriphAdd'] = handlePeriphAdd,
       ['ccpipes-PeriphDel'] = handlePeriphDel,
     }
 

--- a/computercraft/sigils/controller.lua
+++ b/computercraft/sigils/controller.lua
@@ -80,19 +80,17 @@ local function handlePeripheralAttach(periphId, factory, sendMessage)
   local periph = peripheral.wrap(periphId)
   local isInventory = periph['pushItems'] ~= nil
   if isInventory and periph.size() >= 1 then
+    local diff
     if factory.missing[periphId] then
-      local diff = Factory.missingDel(factory, periphId)
-      sendMessage(textutils.serializeJSON({
-        type = "CcUpdatedFactory",
-        diff = diff
-      }))
+      diff = Factory.missingDel(factory, periphId)
     else
-      local diff = Factory.periphAdd(factory, periphId)
-      sendMessage(textutils.serializeJSON({
-        type = "CcUpdatedFactory",
-        diff = diff
-      }))
+      diff = Factory.availableAdd(factory, periphId)
     end
+
+    sendMessage(textutils.serializeJSON({
+      type = "CcUpdatedFactory",
+      diff = diff
+    }))
   end
 end
 

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -381,7 +381,7 @@ local function periphDel (factory, periphId)
   return Utils.concatArrays(unpack(diffs))
 end
 
----Get peripheral IDs connected to this factory
+---Get peripheral IDs connected to the network
 ---@return string[] periphs List of peripheral IDs
 local function getPeripheralIds ()
   local periphs = {}
@@ -417,7 +417,8 @@ local function autodetectFactory ()
 end
 
 ---Given an existing factory, add peripherals that are no longer on the network
----to the missing peripheral set and create machines for newly added peripherals.
+---to the missing peripheral set and add newly added peripherals to the
+---available peripheral set.
 ---@param factory Factory Factory to update with peripheral changes
 local function updateWithPeriphChanges (factory)
   local currentPeriphSet = {}
@@ -440,11 +441,11 @@ local function updateWithPeriphChanges (factory)
     end
   end
 
-  -- add new peripherals:
-  -- add anything in currentPeriphSet that's not in oldPeriphSet
+  -- put newly connected peripherals in available
+  -- (any periphId in currentPeriphSet that's not in oldPeriphSet goes into available)
   for currentPeriphId, _ in pairs(currentPeriphSet) do
     if oldPeriphSet[currentPeriphId] == nil then
-      periphAdd(factory, currentPeriphId)
+      factory.available[currentPeriphId] = true
     end
   end
 
@@ -452,6 +453,13 @@ local function updateWithPeriphChanges (factory)
   for periphId, _ in pairs(factory.missing) do
     if currentPeriphSet[periphId] then
       missingDel(factory, periphId)
+    end
+  end
+
+  -- remove peripherals from available peripheral list that are not longer connected
+  for periphId, _ in pairs(factory.available) do
+    if currentPeriphSet[periphId] == nil then
+      availableDel(factory, periphId)
     end
   end
 end

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -324,9 +324,15 @@ end
 ---Add a peripheral to the factory as a new machine
 ---@param factory Factory Factory to add the peripheral to
 ---@param periphId string Peripheral to add
+---@param initialOptions table? Options to initialize the machine with
 ---@return table diffs List of jsondiffpatch Deltas for the factory
-local function periphAdd (factory, periphId)
+local function periphAdd (factory, periphId, initialOptions)
   local newMachine, newGroups = Machine.fromPeriphId(periphId)
+
+  for option, v in pairs(initialOptions) do
+    newMachine[option] = v
+  end
+
   local periphAttachDiffs = {}
 
   if factory.available[periphId] then

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -237,27 +237,6 @@ local function machineAdd (factory, machine)
   return {diff}
 end
 
----Add a peripheral to the factory as a new machine
----@param factory Factory Factory to add the peripheral to
----@param periphId string Peripheral to add
----@return table diffs List of jsondiffpatch Deltas for the factory
-local function periphAdd (factory, periphId)
-  local newMachine, newGroups = Machine.fromPeriphId(periphId)
-  local periphAttachDiffs = {}
-
-  local machineAddDiff = machineAdd(factory, newMachine)
-  machineAddDiff = Utils.freezeTable(machineAddDiff)
-  table.insert(periphAttachDiffs, machineAddDiff)
-
-  for groupId, group in pairs(newGroups) do
-    local groupAddDiff = groupAdd(factory, group)
-    groupAddDiff = Utils.freezeTable(groupAddDiff)
-    table.insert(periphAttachDiffs, groupAddDiff)
-  end
-
-  return Utils.concatArrays(unpack(periphAttachDiffs))
-end
-
 ---Add a peripheral to the missing peripherals set
 ---@param factory Factory Factory to add to
 ---@param periphId string CC Peripheral ID
@@ -340,6 +319,31 @@ local function availableDel (factory, periphId)
     }
   }
   return {diff}
+end
+
+---Add a peripheral to the factory as a new machine
+---@param factory Factory Factory to add the peripheral to
+---@param periphId string Peripheral to add
+---@return table diffs List of jsondiffpatch Deltas for the factory
+local function periphAdd (factory, periphId)
+  local newMachine, newGroups = Machine.fromPeriphId(periphId)
+  local periphAttachDiffs = {}
+
+  if factory.available[periphId] then
+    table.insert(periphAttachDiffs, availableDel(factory, periphId))
+  end
+
+  local machineAddDiff = machineAdd(factory, newMachine)
+  machineAddDiff = Utils.freezeTable(machineAddDiff)
+  table.insert(periphAttachDiffs, machineAddDiff)
+
+  for groupId, group in pairs(newGroups) do
+    local groupAddDiff = groupAdd(factory, group)
+    groupAddDiff = Utils.freezeTable(groupAddDiff)
+    table.insert(periphAttachDiffs, groupAddDiff)
+  end
+
+  return Utils.concatArrays(unpack(periphAttachDiffs))
 end
 
 ---Remove a peripheral's slots from all groups in the factory.

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -279,7 +279,7 @@ local function missingAdd (factory, periphId)
       end
     end
   end
-  
+
   return {}
 end
 
@@ -292,6 +292,48 @@ local function missingDel (factory, periphId)
 
   local diff = {
     missing = {
+      [periphId] = {
+        nil, 0, 0
+      }
+    }
+  }
+  return {diff}
+end
+
+---Add a peripheral to the available peripherals set
+---@param factory Factory Factory to add to
+---@param periphId string CC Peripheral ID
+---@return table diffs List of jsondiffpatch Deltas for the factory
+local function availableAdd (factory, periphId)
+  -- try to find periphId in the factory. if it's there, it doesn't matter
+  -- because it's in a machine already, so we don't change anything.
+  for _, group in pairs(factory.groups) do
+    for _, slot in pairs(group.slots) do
+      if periphId == slot.periphId then
+        factory.available[periphId] = true
+
+        local diff = {
+          available = {
+            [periphId] = {true}
+          }
+        }
+        return {diff}
+      end
+    end
+  end
+
+  return {}
+end
+
+---Delete a peripheral from the available peripherals set
+---@param factory Factory Factory to delete from to
+---@param periphId string CC Peripheral ID
+---@return table diffs List of jsondiffpatch Deltas for the factory
+local function availableDel (factory, periphId)
+  factory.available[periphId] = nil
+
+  local diff = {
+    available = {
       [periphId] = {
         nil, 0, 0
       }
@@ -424,6 +466,8 @@ return {
   periphDel = periphDel,
   missingAdd = missingAdd,
   missingDel = missingDel,
+  availableAdd = availableAdd,
+  availableDel = availableDel,
   autodetectFactory = autodetectFactory,
   updateWithPeriphChanges = updateWithPeriphChanges,
   saveFactory = saveFactory,

--- a/computercraft/sigils/factory.lua
+++ b/computercraft/sigils/factory.lua
@@ -289,19 +289,19 @@ local function availableAdd (factory, periphId)
   for _, group in pairs(factory.groups) do
     for _, slot in pairs(group.slots) do
       if periphId == slot.periphId then
-        factory.available[periphId] = true
-
-        local diff = {
-          available = {
-            [periphId] = {true}
-          }
-        }
-        return {diff}
+        return {}
       end
     end
   end
 
-  return {}
+  factory.available[periphId] = true
+
+  local diff = {
+    available = {
+      [periphId] = {true}
+    }
+  }
+  return {diff}
 end
 
 ---Delete a peripheral from the available peripherals set
@@ -403,6 +403,7 @@ local function autodetectFactory ()
     groups = {},
     pipes = {},
     missing = {},
+    available = {},
   }
   for i, periphId in ipairs(getPeripheralIds()) do
     local machine, groups = Machine.fromPeriphId(periphId)

--- a/computercraft/sigils/websocket.lua
+++ b/computercraft/sigils/websocket.lua
@@ -22,6 +22,7 @@ local MESSAGE_TYPES = {
   GroupAdd = true,
   GroupEdit = true,
   GroupDel = true,
+  PeriphAdd = true,
   PeriphDel = true
 }
 
@@ -120,7 +121,7 @@ local function queueEventFromMessage (message)
     print('Press E to create a new factory editing session.')
     return true
   else
-    print('Unhandled message type in websocket.lua: ' .. messageType)
+    LOGGER.warn('Unhandled message type in websocket.lua: ' .. messageType)
     return false
   end
 end

--- a/server/src/types/core-types.ts
+++ b/server/src/types/core-types.ts
@@ -17,12 +17,15 @@
  * - Pipes connect Groups together to transfer items between them.
  * - Missing peripherals are peripherals that may be part of some Machine(s) but
  *   are disconnected from the network
+ * - Available peripherals are peripherals that are connected to the CC network
+ *   but not part of any Machine
  */
 export interface Factory {
     pipes: PipeMap,
     machines: MachineMap,
     groups: GroupMap,
-    missing: MissingPeriphMap,
+    missing: PeriphMap,
+    available: PeriphMap,
 }
 
 export type PipeId = string;
@@ -42,9 +45,9 @@ export interface Pipe {
 export type PeriphId = string;
 
 /**
- * A Lua-style set of Peripheral IDs missing from the CC network
+ * A Lua-style set of Peripheral IDs
  */
-export type MissingPeriphMap = { [key: PeriphId]: boolean }
+export type PeriphMap = { [key: PeriphId]: boolean }
 
 /**
  * Data structure representing a slot on a particular peripheral

--- a/server/src/types/messages.ts
+++ b/server/src/types/messages.ts
@@ -7,7 +7,7 @@ export const FACTORY_UPDATE_REQUEST_TYPES = [
   "PipeAdd", "PipeEdit", "PipeDel",
   "MachineAdd", "MachineEdit", "MachineDel",
   "GroupAdd", "GroupEdit", "GroupDel",
-  "PeriphDel",
+  "PeriphAdd", "PeriphDel",
 ] as const;
 
 export type FactoryUpdateRequest = typeof FACTORY_UPDATE_REQUEST_TYPES[number];
@@ -237,12 +237,17 @@ export interface GroupAddReq extends Request {
   machineId: MachineId,
 }
 
+export interface PeriphAddReq extends Request {
+  type: "PeriphAdd",
+  periphId: PeriphId,
+}
+
 /**
  * Request to delete a peripheral from the factory.
  * 
  * - Emitted from the editor when the user wants to delete a missing peripheral
  */
-export interface PeriphDel extends Request {
+export interface PeriphDelReq extends Request {
   type: "PeriphDel",
   periphId: PeriphId,
 }

--- a/server/src/types/messages.ts
+++ b/server/src/types/messages.ts
@@ -237,9 +237,14 @@ export interface GroupAddReq extends Request {
   machineId: MachineId,
 }
 
+/**
+ * Request to add a peripheral to the factory as a Machine
+ * You can optionally specify machine options to initialize the Machine with
+ */
 export interface PeriphAddReq extends Request {
   type: "PeriphAdd",
   periphId: PeriphId,
+  options?: Partial<Machine>,
 }
 
 /**


### PR DESCRIPTION
Instead of adding a peripheral to the factory directly when connected to the network, this will add it to the available peripheral set, and the user can choose to add it themselves.

Mainly to work around the annoying layout jank that happens when new machines get added when other machines have been moved by the user already.