### PR TITLE
add tentative plethora (1.12.2) support

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -82,12 +82,12 @@ export default function App() {
   );
 
   const onEdgesDelete: OnEdgesDelete = useCallback(
-    (edges) => GraphUpdateCallbacks.onEdgesDelete(edges, sendMessage, addReqNeedingLayout),
+    (edges) => GraphUpdateCallbacks.onEdgesDelete(edges, sendMessage),
     [sendMessage, addReqNeedingLayout]
   );
 
   const onEdgeUpdate: OnEdgeUpdateFunc = useCallback(
-    (oldEdge, newConnection) => GraphUpdateCallbacks.onEdgeUpdate(oldEdge, newConnection, sendMessage, addReqNeedingLayout),
+    (oldEdge, newConnection) => GraphUpdateCallbacks.onEdgeUpdate(oldEdge, newConnection, sendMessage),
     [sendMessage, setEdges, addReqNeedingLayout]
   );
 
@@ -250,7 +250,6 @@ export default function App() {
         />
       }
       { tempEdge && <TempEdgeOptions
-          addReqNeedingLayout={ addReqNeedingLayout }
           sendMessage={ sendMessage }
           setTempEdge={ setTempEdge }
           tempEdge={ tempEdge }

--- a/client/src/GraphUpdateCallbacks.ts
+++ b/client/src/GraphUpdateCallbacks.ts
@@ -11,7 +11,6 @@ import { AvailablePeripheralBadgeDragData } from "./components/AvailablePeripher
 function onEdgesDelete(
   edges: Edge[],
   sendMessage: SendMessage,
-  addReqNeedingLayout: (reqId: string) => void
 ) {
   for (let edge of edges) {
     const reqId = uuidv4();
@@ -20,7 +19,6 @@ function onEdgesDelete(
       reqId: reqId,
       pipeId: edge.id,
     };
-    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(pipeDelReq));
   }
 }
@@ -53,7 +51,6 @@ function onEdgeUpdate(
   oldEdge: Edge,
   newConnection: Connection,
   sendMessage: SendMessage,
-  addReqNeedingLayout: (reqId: string) => void
 ) {
   if (newConnection.source !== null && newConnection.target !== null) {
     const reqId = uuidv4();
@@ -66,7 +63,6 @@ function onEdgeUpdate(
         to: newConnection.target,
       }
     };
-    addReqNeedingLayout(reqId);
     sendMessage(JSON.stringify(pipeEditReq));
   }
 }

--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -4,13 +4,13 @@ import { SendMessage } from "react-use-websocket";
 import { Edge, useOnSelectionChange, useStoreApi } from "reactflow";
 import { GraphUpdateCallbacks } from "../GraphUpdateCallbacks";
 import { useFactoryStore } from "../stores/factory";
+import { FilterSyntax } from "./FilterSyntax";
 
 interface EdgeOptionsProps {
   sendMessage: SendMessage,
-  addReqNeedingLayout: (reqId: string) => void,
 };
 
-export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsProps) {
+export function EdgeOptions({ sendMessage }: EdgeOptionsProps) {
   const [ selectedEdges, setSelectedEdges ] = useState([] as Edge[]);
 
   const pipes = useFactoryStore(state => state.factory.pipes);
@@ -88,28 +88,7 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
             value={ filter }
             onInput={ e => setFilter((e.target as HTMLInputElement).value) }
           />
-          <details className="text-sm text-neutral-700 mt-1 w-full">
-            <summary className="cursor-pointer">Advanced syntax</summary>
-
-            <p>
-              Prefix a term with an exclamation mark (!) to exclude it:
-              <blockquote className="ps-5">!cobblestone</blockquote>
-            </p>
-
-            <p>
-              Filter supports JEI prefixes for:
-              <ul className="list-disc ps-5">
-                <li>@mod_name</li>
-                <li>&item_id</li>
-                <li>$ore_dict</li>
-              </ul>
-            </p>
-
-            <p>
-              To match multiple filters, use the pipe (|) character:
-              <blockquote className="ps-5">iron ore | dirt | cobblestone</blockquote>
-            </p>
-          </details>
+          <FilterSyntax />
         </div>
 
         <div className="text-right box-border">

--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -115,7 +115,7 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
         <div className="text-right box-border">
           <button
             className="mcui-button bg-red-700 w-32 h-10 me-3"
-            onClick={ () => GraphUpdateCallbacks.onEdgesDelete(selectedEdges, sendMessage, addReqNeedingLayout) }
+            onClick={ () => GraphUpdateCallbacks.onEdgesDelete(selectedEdges, sendMessage) }
           >
             Delete
           </button>

--- a/client/src/components/FilterSyntax.tsx
+++ b/client/src/components/FilterSyntax.tsx
@@ -1,0 +1,26 @@
+export function FilterSyntax () {
+  return (
+    <details className="text-sm text-neutral-700 mt-1 w-full">
+      <summary className="cursor-pointer">Advanced syntax</summary>
+
+      <p>
+        Prefix a term with an exclamation mark (!) to exclude it:
+        <blockquote className="ps-5">!cobblestone</blockquote>
+      </p>
+
+      <p>
+        Filter supports JEI prefixes for:
+      </p>
+      <ul className="list-disc ps-5">
+        <li>@mod_name</li>
+        <li>&item_id</li>
+        <li>$ore_dict</li>
+      </ul>
+
+      <p>
+        To match multiple filters, use the pipe (|) character:
+        <blockquote className="ps-5">iron ore | dirt | cobblestone</blockquote>
+      </p>
+    </details>
+  )
+}

--- a/client/src/components/TempEdgeOptions.tsx
+++ b/client/src/components/TempEdgeOptions.tsx
@@ -3,6 +3,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import { SendMessage } from "react-use-websocket";
 import { Edge } from "reactflow";
 import { v4 as uuidv4 } from "uuid";
+import { FilterSyntax } from "./FilterSyntax";
 
 export interface TempEdgeOptionsProps {
   sendMessage: SendMessage,
@@ -65,6 +66,7 @@ export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }
             value={ filter }
             onInput={ e => setFilter((e.target as HTMLInputElement).value) }
           />
+          <FilterSyntax />
         </div>
 
         <div className="text-right box-border">

--- a/client/src/components/TempEdgeOptions.tsx
+++ b/client/src/components/TempEdgeOptions.tsx
@@ -9,10 +9,9 @@ export interface TempEdgeOptionsProps {
   tempEdge: (Edge | null),
   setTempEdge: Dispatch<SetStateAction<Edge | null>>,
   onCancel: () => void,
-  addReqNeedingLayout: (reqId: string) => void,
 };
 
-export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel, addReqNeedingLayout }: TempEdgeOptionsProps) {
+export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }: TempEdgeOptionsProps) {
   const [ nickname, setNickname ] = useState("");
   const [ filter, setFilter ] = useState("");
 
@@ -33,7 +32,6 @@ export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel, 
     if (nickname !== "") pipeAddReq.pipe.nickname = nickname;
     if (filter !== "") pipeAddReq.pipe.filter = filter;
 
-    addReqNeedingLayout(reqId);
     setTempEdge(null);
     sendMessage(JSON.stringify(pipeAddReq));
   }

--- a/computercraft/sigils/ItemDetailAndLimitCache.lua
+++ b/computercraft/sigils/ItemDetailAndLimitCache.lua
@@ -45,7 +45,8 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
             function ()
               local periph = peripheral.wrap(slot.periphId)
               if periph and o.map[slotId].itemDetail == nil then
-                o.map[slotId].itemDetail = periph.getItemDetail(slot.slot)
+                local getItemDetail = periph.getItemDetail or periph.getItemMeta
+                o.map[slotId].itemDetail = getItemDetail(slot.slot)
               end
             end
           )
@@ -55,7 +56,8 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
             function ()
               local periph = peripheral.wrap(slot.periphId)
               if periph and o.map[slotId].itemLimit == nil then
-                o.map[slotId].itemLimit = periph.getItemLimit(slot.slot)
+                local getItemLimit = periph.getItemLimit or function () return 64 end
+                o.map[slotId].itemLimit = getItemLimit(slot.slot)
               end
             end
           )

--- a/computercraft/sigils/pipe.lua
+++ b/computercraft/sigils/pipe.lua
@@ -62,7 +62,9 @@ local function processPipe (pipe, groupMap, missingPeriphs)
       end
       table.insert(coros, coro)
     end
-    parallel.waitForAll(unpack(coros))
+    if #coros > 0 then
+      parallel.waitForAll(unpack(coros))
+    end
   else
     LOGGER:warn("pipe.lua#processPipe() caught error " .. transferOrders)
   end


### PR DESCRIPTION
This PR tentatively adds support for piping items in 1.12.2 using the Plethora mod.

If SIGILS is unable to use a method provided by inventory peripherals, it will try to use one provided by Plethora.

Also there's some other bugs that exist in 1.12.2 that are causing problems, including in the editor, so I Plethora cannot yet be considered fully supported.