### PR TITLE
Add spread mode

### DIFF
--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -110,6 +110,7 @@ export function EdgeOptions({ sendMessage }: EdgeOptionsProps) {
               className="mcui-button p-2 w-full h-10"
             >
               <option value="natural">Natural (default)</option>
+              <option value="spread">Spread</option>
             </select>
           </div>
         }

--- a/client/src/components/TempEdgeOptions.tsx
+++ b/client/src/components/TempEdgeOptions.tsx
@@ -4,6 +4,8 @@ import { SendMessage } from "react-use-websocket";
 import { Edge } from "reactflow";
 import { v4 as uuidv4 } from "uuid";
 import { FilterSyntax } from "./FilterSyntax";
+import { useFactoryStore } from "../stores/factory";
+import { PipeMode } from "@server/types/core-types";
 
 export interface TempEdgeOptionsProps {
   sendMessage: SendMessage,
@@ -15,6 +17,11 @@ export interface TempEdgeOptionsProps {
 export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }: TempEdgeOptionsProps) {
   const [ nickname, setNickname ] = useState("");
   const [ filter, setFilter ] = useState("");
+  const [ mode, setMode ] = useState("");
+
+  const groups = useFactoryStore(state => state.factory.groups);
+
+  const isFluid = tempEdge && groups[tempEdge.source].fluid;
 
   function onCommit() {
     if (!(tempEdge && tempEdge.source && tempEdge.target)) return;
@@ -32,6 +39,7 @@ export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }
 
     if (nickname !== "") pipeAddReq.pipe.nickname = nickname;
     if (filter !== "") pipeAddReq.pipe.filter = filter;
+    if (mode !== "") pipeAddReq.pipe.mode = mode as PipeMode;
 
     setTempEdge(null);
     sendMessage(JSON.stringify(pipeAddReq));
@@ -56,7 +64,7 @@ export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }
           />
         </div>
 
-        <div className="flex flex-col mb-5">
+        <div className="flex flex-col mb-3">
           <label htmlFor="pipeFilter" className="mb-1">Item filter</label>
           <input
             type="text"
@@ -68,6 +76,20 @@ export function TempEdgeOptions({ tempEdge, setTempEdge, sendMessage, onCancel }
           />
           <FilterSyntax />
         </div>
+
+        { !isFluid &&
+          <div className="mb-5">
+            <label htmlFor="mode" className="block mb-1">Mode</label>
+            <select
+              value={ mode }
+              onChange={ e => setMode(e.target.value) }
+              className="mcui-button p-2 w-full h-10"
+            >
+              <option value="natural">Natural (default)</option>
+              <option value="spread">Spread</option>
+            </select>
+          </div>
+        }
 
         <div className="text-right box-border">
           <button

--- a/computercraft/sigils/pipe.lua
+++ b/computercraft/sigils/pipe.lua
@@ -4,10 +4,14 @@
 ---A data structure for a Pipe matching `/server/src/types/core-types.ts#Pipe`
 ---@class Pipe
 
-local PipeModeNatural = require('sigils.pipeModes.natural')
 local PipeModeFluid = require('sigils.pipeModes.fluid')
 local Filter = require('sigils.filter')
 local LOGGER = require('sigils.logging').LOGGER
+
+local ITEM_PIPE_MODES = {
+  natural = require('sigils.pipeModes.natural'),
+  spread = require('sigils.pipeModes.spread'),
+}
 
 local function processFluidPipe (pipe, groupMap, missingPeriphs, filter)
   local ok, transferOrders = pcall(
@@ -47,11 +51,8 @@ local function processPipe (pipe, groupMap, missingPeriphs)
 
   local ok, transferOrders = pcall(
     function ()
-      if pipe.mode == "natural" then -- you can add more item pipe modes with more if/else statements
-        return PipeModeNatural.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], missingPeriphs, filter)
-      else -- natural is the default
-        return PipeModeNatural.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], missingPeriphs, filter)
-      end
+      local pipeMode = ITEM_PIPE_MODES[pipe.mode] or ITEM_PIPE_MODES["natural"]
+      return pipeMode.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], missingPeriphs, filter)
     end
   )
 

--- a/computercraft/sigils/pipeModes/spread.lua
+++ b/computercraft/sigils/pipeModes/spread.lua
@@ -1,18 +1,23 @@
 local ItemDetailAndLimitCache = require('sigils.ItemDetailAndLimitCache')
 
-local function getTotalDestSlotsAvailableForOriginSlot(inventoryInfo, originSlot, emptySlotQueue)
-  local originItem = inventoryInfo:GetItemDetail(originSlot)
-  local possibleSlotsFull = inventoryInfo:GetSlotsWithMatchingItems(destination, function (item)
-    return (item.name == originItem.name and
-      item.nbt == nil and
-      item.durability == nil and
-      item.maxCount > item.count
-    )
-  end)
+---Get the amount of items from the origin item stack that can be moved to the
+---destination item stack.
+---@param originStack table ItemDetail of the origin item stack
+---@param destStack table ItemDetail of the destination item stack
+---@return number Number Number of items that can be moved. 0 if destination full or unstackable.
+local function getAmountStackable(originStack, destStack)
+  local isCompatibleItem = (
+    destStack.name == originStack.name and
+    destStack.nbt == nil and
+    destStack.durability == nil and
+    destStack.maxCount > originStack.count
+  )
 
-  local emptySlotsAvailable = #emptySlotQueue
-
-  return emptySlotsAvailable + #possibleSlotsFull
+  if isCompatibleItem then
+    return destStack.maxCount - originStack.count
+  else
+    return 0
+  end
 end
 
 local function getTransferOrders (origin, destination, missingPeriphs, filter)
@@ -24,26 +29,26 @@ local function getTransferOrders (origin, destination, missingPeriphs, filter)
   local emptySlotQueue = inventoryInfo:GetEmptySlots()
 
   for _, originSlot in pairs(origin.slots) do
-    local totalDestSlotsAvailable = getTotalDestSlotsAvailableForOriginSlot(
-      inventoryInfo, originSlot, emptySlotQueue)
+    local originStack = inventoryInfo:GetItemDetail(originSlot) -- TODO: expecting this to be nil if the destSlot is empty. Is this true?
+    if originStack then
+      local toTransfer = originStack.count
+      local actualTransferred = 0
 
-    if totalDestSlotsAvailable == 0 then break end
+      local numDestinationSlots = min(slot_count, #destination.slots)
+      local transferAmount = floor(toTransfer / numDestinationSlots) -- we'll try to transfer this many items to each destination slot
 
-    local itemsPerDestSlot = inventoryInfo:GetNumExistingItemsAt(originSlot) / totalDestSlotsAvailable
-    local originStackSize = inventoryInfo:GetNumExistingItemsAt(originSlot)
+      for writeHead=1, numDestinationSlots do
+        local destSlot = destination.slots[writeHead]
+        local destStack = inventoryInfo:GetItemDetail(destSlot) -- TODO: expecting this to be nil if the destSlot is empty. Is this true?
 
-    -- reserve a certain number of slots equal to origin stack size // total available dest slots
-    for i=1, math.floor(originStackSize / totalDestSlotsAvailable) do
-      table.insert(order, {from=originSlot, to=possibleDestSlot, limit=originStackSize})
+        if destStack or getAmountStackable(originStack, destStack) then
+          local transferLimit = min(inventoryInfo:GetItemLimit(destSlot) - destStack.count, transferAmount)
+          actualTransferred = actualTransferred + transferLimit
+
+          table.insert(orders, {from=originSlot, to=destSlot, limit=transferLimit})
+        end
+      end
     end
-
-    -- if there's a remainder, reserve another slot and transfer the remainder
-    local itemsRemaining = itemsPerDestSlot % totalDestSlotsAvailable
-    table.insert(order, {from=originSlot, to=possibleDestSlot, limit=originStackSize})
-    if itemsRemaining then
-      table.insert(order, {from=originSlot, to=possibleDestSlot, limit=itemsRemaining})
-    end
-
   end
 
   return orders

--- a/computercraft/sigils/pipeModes/spread.lua
+++ b/computercraft/sigils/pipeModes/spread.lua
@@ -26,7 +26,7 @@ local function getTransferOrders (origin, destination, missingPeriphs, filter)
   local inventoryInfo = ItemDetailAndLimitCache.new(missingPeriphs)
   inventoryInfo:Fulfill({origin, destination})
 
-  for _, originSlot in pairs(origin.slots) do
+  for _, originSlot in pairs(inventoryInfo:GetSlotsWithMatchingItems(origin, filter)) do
     local originStack = inventoryInfo:GetItemDetail(originSlot)
     if originStack then
       local toTransfer = originStack.count

--- a/computercraft/sigils/pipeModes/spread.lua
+++ b/computercraft/sigils/pipeModes/spread.lua
@@ -1,0 +1,54 @@
+local ItemDetailAndLimitCache = require('sigils.ItemDetailAndLimitCache')
+
+local function getTotalDestSlotsAvailableForOriginSlot(inventoryInfo, originSlot, emptySlotQueue)
+  local originItem = inventoryInfo:GetItemDetail(originSlot)
+  local possibleSlotsFull = inventoryInfo:GetSlotsWithMatchingItems(destination, function (item)
+    return (item.name == originItem.name and
+      item.nbt == nil and
+      item.durability == nil and
+      item.maxCount > item.count
+    )
+  end)
+
+  local emptySlotsAvailable = #emptySlotQueue
+
+  return emptySlotsAvailable + #possibleSlotsFull
+end
+
+local function getTransferOrders (origin, destination, missingPeriphs, filter)
+  local orders = {}
+
+  local inventoryInfo = ItemDetailAndLimitCache.new(missingPeriphs)
+  inventoryInfo:Fulfill({origin, destination})
+
+  local emptySlotQueue = inventoryInfo:GetEmptySlots()
+
+  for _, originSlot in pairs(origin.slots) do
+    local totalDestSlotsAvailable = getTotalDestSlotsAvailableForOriginSlot(
+      inventoryInfo, originSlot, emptySlotQueue)
+
+    if totalDestSlotsAvailable == 0 then break end
+
+    local itemsPerDestSlot = inventoryInfo:GetNumExistingItemsAt(originSlot) / totalDestSlotsAvailable
+    local originStackSize = inventoryInfo:GetNumExistingItemsAt(originSlot)
+
+    -- reserve a certain number of slots equal to origin stack size // total available dest slots
+    for i=1, math.floor(originStackSize / totalDestSlotsAvailable) do
+      table.insert(order, {from=originSlot, to=possibleDestSlot, limit=originStackSize})
+    end
+
+    -- if there's a remainder, reserve another slot and transfer the remainder
+    local itemsRemaining = itemsPerDestSlot % totalDestSlotsAvailable
+    table.insert(order, {from=originSlot, to=possibleDestSlot, limit=originStackSize})
+    if itemsRemaining then
+      table.insert(order, {from=originSlot, to=possibleDestSlot, limit=itemsRemaining})
+    end
+
+  end
+
+  return orders
+end
+
+return {
+  getTransferOrders = getTransferOrders,
+}

--- a/computercraft/sigils/pipeModes/spread.lua
+++ b/computercraft/sigils/pipeModes/spread.lua
@@ -20,6 +20,23 @@ local function getAmountStackable(originStack, destStack, destItemLimit)
   end
 end
 
+---Get the transfer orders needed to spread items from the origin inventory throughout
+---the destination inventory.
+---
+---This emulates the spreading behavior of Minecraft. For instance, if you drag
+---a stack of items in your cursor into several slots on a chest, the stack is
+---divided evenly, and each portion is added to the destination slots.
+---The remainder remains in your cursor, in addition to any items that couldn't
+---be fully transferred.
+---
+---This function uses slots in the origin inventory as the "cursor," which is
+---why some remainder items stay in the origin inventory after a single pass.
+---
+---@param origin Group Origin group to transfer from
+---@param destination Group Destination group to transfer to
+---@param missingPeriphs table Set of missing peripherals by ID
+---@param filter function Filter function that accepts the result of inventory.getItemDetail()
+---@return TransferOrder[] transferOrders List of transfer orders
 local function getTransferOrders (origin, destination, missingPeriphs, filter)
   local orders = {}
 

--- a/computercraft/sigils/pipeModes/spread.lua
+++ b/computercraft/sigils/pipeModes/spread.lua
@@ -4,17 +4,17 @@ local ItemDetailAndLimitCache = require('sigils.ItemDetailAndLimitCache')
 ---destination item stack.
 ---@param originStack table ItemDetail of the origin item stack
 ---@param destStack table ItemDetail of the destination item stack
+---@param destItemLimit table Item limit of the destination item stack
 ---@return number Number Number of items that can be moved. 0 if destination full or unstackable.
-local function getAmountStackable(originStack, destStack)
+local function getAmountStackable(originStack, destStack, destItemLimit)
   local isCompatibleItem = (
     destStack.name == originStack.name and
     destStack.nbt == nil and
-    destStack.durability == nil and
-    destStack.maxCount > originStack.count
+    destStack.durability == nil
   )
 
   if isCompatibleItem then
-    return destStack.maxCount - originStack.count
+    return math.min(destStack.maxCount - destStack.count, originStack.count, destItemLimit)
   else
     return 0
   end
@@ -41,11 +41,12 @@ local function getTransferOrders (origin, destination, missingPeriphs, filter)
       for writeHead=1, numDestinationSlots do
         local destSlot = destination.slots[writeHead]
         local destStack = inventoryInfo:GetItemDetail(destSlot)
+        local destItemLimit = inventoryInfo:GetItemLimit(destSlot)
 
-        if destStack == nil or getAmountStackable(originStack, destStack) > 0 then
+        if destStack == nil or getAmountStackable(originStack, destStack, destItemLimit) > 0 then
           local transferLimit = transferAmount
           if destStack ~= nil then
-            transferLimit = math.min(getAmountStackable(originStack, destStack), transferAmount)
+            transferLimit = math.min(getAmountStackable(originStack, destStack, destItemLimit), transferAmount)
           end
           actualTransferred = actualTransferred + transferLimit
 


### PR DESCRIPTION
This PR contains a spread mode that I started implementing before I stopped playing my modded Minecraft playthrough. It is incomplete and untested. For instance, it ignores the filter defined by the user.

Basically, it looks at each slot in the origin inventory, detects slots where the item could go, and divides the items in the origin slot between the slots in the destination.