### PR TITLE
Add pipe mode selector

### DIFF
--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -1,4 +1,4 @@
-import { Pipe } from "@server/types/core-types";
+import { Pipe, PipeMode } from "@server/types/core-types";
 import { useState } from "react";
 import { SendMessage } from "react-use-websocket";
 import { Edge, useOnSelectionChange, useStoreApi } from "reactflow";
@@ -17,12 +17,14 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
 
   const [ nickname, setNickname ] = useState("");
   const [ filter, setFilter ] = useState("");
+  const [ mode, setMode ] = useState(undefined as string | undefined);
 
   useOnSelectionChange({
     onChange: ({ edges }) => {
       setSelectedEdges(edges);
       setFilter(edges.length === 1 ? (pipes[edges[0].id].filter || "") : "...");
       setNickname(edges.length === 1 ? (pipes[edges[0].id].nickname || "") : "...");
+      setMode(edges.length === 1 ? pipes[edges[0].id].mode : "...");
     }
   });
 
@@ -37,6 +39,11 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
     
     if (filter !== "...") {
       edits.filter = filter;
+      changes = true;
+    }
+
+    if (mode && mode !== "...") {
+      edits.mode = mode as PipeMode;
       changes = true;
     }
 
@@ -80,8 +87,11 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
         
         <div className="flex flex-col mb-5">
           <label htmlFor="mode" className="mb-1">Mode</label>
-          <select>
-            <option value="natural">natural</option>
+          <select
+            defaultValue={ mode }
+            onInput={ e => setMode((e.target as HTMLInputElement).value) }
+          >
+            <option value="natural">Natural (default)</option>
           </select>
         </div>
 

--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -88,8 +88,8 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
         <div className="flex flex-col mb-5">
           <label htmlFor="mode" className="mb-1">Mode</label>
           <select
-            defaultValue={ mode }
-            onInput={ e => setMode((e.target as HTMLInputElement).value) }
+            value={ mode }
+            onChange={ e => setMode(e.target.value) }
           >
             <option value="natural">Natural (default)</option>
           </select>

--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -14,9 +14,11 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
   const [ selectedEdges, setSelectedEdges ] = useState([] as Edge[]);
 
   const pipes = useFactoryStore(state => state.factory.pipes);
+  const groups = useFactoryStore(state => state.factory.groups);
 
   const [ nickname, setNickname ] = useState("");
   const [ filter, setFilter ] = useState("");
+  const [ isFluid, setIsFluid ] = useState(false);
   const [ mode, setMode ] = useState(undefined as string | undefined);
 
   useOnSelectionChange({
@@ -25,6 +27,7 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
       setFilter(edges.length === 1 ? (pipes[edges[0].id].filter || "") : "...");
       setNickname(edges.length === 1 ? (pipes[edges[0].id].nickname || "") : "...");
       setMode(edges.length === 1 ? pipes[edges[0].id].mode : "...");
+      setIsFluid(edges.length > 0 && groups[pipes[edges[0].id].from].fluid === true);
     }
   });
 
@@ -84,19 +87,8 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
             onInput={ e => setNickname((e.target as HTMLInputElement).value) }
           />
         </div>
-        
-        <div className="mb-5">
-          <label htmlFor="mode" className="block mb-1">Mode</label>
-          <select
-            value={ mode }
-            onChange={ e => setMode(e.target.value) }
-            className="mcui-button p-2 w-full h-10"
-          >
-            <option value="natural">Natural (default)</option>
-          </select>
-        </div>
 
-        <div className="flex flex-col mb-5">
+        <div className="flex flex-col mb-3">
           <label htmlFor="pipeFilter" className="mb-1">Item filter</label>
           <input
             type="text"
@@ -129,6 +121,20 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
             </p>
           </details>
         </div>
+
+        { !isFluid &&
+          <div className="mb-5">
+            <label htmlFor="mode" className="block mb-1">Mode</label>
+            <select
+              value={ mode }
+              onChange={ e => setMode(e.target.value) }
+              className="mcui-button p-2 w-full h-10"
+            >
+              <option value="natural">Natural (default)</option>
+            </select>
+          </div>
+        }
+        
 
         <div className="text-right box-border">
           <button

--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -85,11 +85,12 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
           />
         </div>
         
-        <div className="flex flex-col mb-5">
-          <label htmlFor="mode" className="mb-1">Mode</label>
+        <div className="mb-5">
+          <label htmlFor="mode" className="block mb-1">Mode</label>
           <select
             value={ mode }
             onChange={ e => setMode(e.target.value) }
+            className="mcui-button p-2 w-full h-10"
           >
             <option value="natural">Natural (default)</option>
           </select>

--- a/client/src/components/EdgeOptions.tsx
+++ b/client/src/components/EdgeOptions.tsx
@@ -77,6 +77,13 @@ export function EdgeOptions({ sendMessage, addReqNeedingLayout }: EdgeOptionsPro
             onInput={ e => setNickname((e.target as HTMLInputElement).value) }
           />
         </div>
+        
+        <div className="flex flex-col mb-5">
+          <label htmlFor="mode" className="mb-1">Mode</label>
+          <select>
+            <option value="natural">natural</option>
+          </select>
+        </div>
 
         <div className="flex flex-col mb-5">
           <label htmlFor="pipeFilter" className="mb-1">Item filter</label>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -30,6 +30,7 @@
   .mcui-button {
     @apply bg-neutral-500;
     @apply text-white;
+    @apply outline-white;
     @apply border-2;
     @apply border-t-mcgui-slot-border-light;
     @apply border-s-mcgui-slot-border-light;
@@ -42,10 +43,10 @@
     @apply disabled:bg-stone-800;
 
     @apply hover:border-white;
-    @apply hover:border-4;
+    @apply hover:outline;
     
     @apply active:border-white;
-    @apply active:border-4;
+    @apply active:outline-2;
     @apply active:bg-stone-700;
 
     text-shadow: 1.5px 1.5px 0px #373737;

--- a/computercraft/sigils/pipe.lua
+++ b/computercraft/sigils/pipe.lua
@@ -47,7 +47,11 @@ local function processPipe (pipe, groupMap, missingPeriphs)
 
   local ok, transferOrders = pcall(
     function ()
-      return PipeModeNatural.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], missingPeriphs, filter)
+      if pipe.mode == "natural" then -- you can add more item pipe modes with more if/else statements
+        return PipeModeNatural.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], missingPeriphs, filter)
+      else -- natural is the default
+        return PipeModeNatural.getTransferOrders(groupMap[pipe.from], groupMap[pipe.to], missingPeriphs, filter)
+      end
     end
   )
 

--- a/server/src/types/core-types.ts
+++ b/server/src/types/core-types.ts
@@ -31,6 +31,8 @@ export interface Factory {
 export type PipeId = string;
 export type PipeMap = { [key: PipeId]: Pipe };
 
+export type PipeMode = 'natural' | 'spread';
+
 /**
  * Data structure representing a pipe for transferring items between two Groups
  */
@@ -38,6 +40,7 @@ export interface Pipe {
     id: PipeId,
     from: GroupId,
     to: GroupId
+    mode?: PipeMode,
     nickname?: string,
     filter?: string,
 };


### PR DESCRIPTION
This adds an optional `mode` attribute to pipes and a selector for the pipe mode in the editor. Right now the only option is "natural", but the item spread mode is planned and this will allow the user to select it when it is implemented.

If a pipe has no mode, then by default it is natural, and is therefore backwards compatible with factories from older versions of SIGILS.