### PR TITLE
Use default runner for entire program

### DIFF
--- a/computercraft/sigils/ItemDetailAndLimitCache.lua
+++ b/computercraft/sigils/ItemDetailAndLimitCache.lua
@@ -29,7 +29,7 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
   ---Fulfills the item details for each slot in the given groups in parallel
   ---@param groups Group[] List of groups to fulfill item limits and details for
   function o:Fulfill(groups)
-    local runner = Concurrent.create_runner(64)
+    local runner = Concurrent.default_runner
 
     for _, group in pairs(groups) do
       for _, slot in pairs(group.slots) do

--- a/computercraft/sigils/concurrent.lua
+++ b/computercraft/sigils/concurrent.lua
@@ -123,4 +123,5 @@ end
 return {
   create_future = create_future,
   create_runner = create_runner,
+  default_runner = create_runner(128),
 }


### PR DESCRIPTION
This PR fixes #42, so instead of spawning task runners individually in multiple coroutines in, one default task runner is created in `concurrent.lua` and used throughout SIGILS.