### PR TITLE
Fix concurrency issues for complicated factories

### DIFF
--- a/computercraft/sigils/ItemDetailAndLimitCache.lua
+++ b/computercraft/sigils/ItemDetailAndLimitCache.lua
@@ -68,6 +68,24 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
     runner.run_until_done()
   end
 
+  ---Fulfills the item details for all groups that are the origin or destination
+  ---of a set of pipes
+  ---
+  ---NOTE: This function will try to fulfill the same slot multiple times if
+  ---there are any pipes passed in that operate on the same groups, which isn't
+  ---efficient. For now, this doesn't matter because the only place this cache
+  ---is needed is running the pipes, which are separated via the edge coloring
+  ---algo.
+  ---@param pipes Pipe[] Array of pipes whose origin/destinations groups should be fulfilled
+  function o:FulfillPipes (pipes, groupMap)
+    local groups = {}
+    for _, pipe in pairs(pipes) do
+      table.insert(groups, groupMap[pipe.from])
+      table.insert(groups, groupMap[pipe.to])
+    end
+    o:Fulfill(groups)
+  end
+
   ---Get the item limit of the given Slot
   ---(This is max number of items holdable by the slot, regardless of whether
   ---an item is in the slot)

--- a/computercraft/sigils/concurrent.lua
+++ b/computercraft/sigils/concurrent.lua
@@ -123,5 +123,5 @@ end
 return {
   create_future = create_future,
   create_runner = create_runner,
-  default_runner = create_runner(32),
+  default_runner = create_runner(128),
 }

--- a/computercraft/sigils/pipeModes/natural.lua
+++ b/computercraft/sigils/pipeModes/natural.lua
@@ -23,14 +23,11 @@ end
 ---Minecraft's shift-click behavior in inventory GUIs.
 ---@param origin Group Origin group to transfer from
 ---@param destination Group Destination group to transfer to
----@param missingPeriphs table Set of missing peripherals by ID
+---@param inventoryInfo table Inventory detail and item limit cache
 ---@param filter function Filter function that accepts the result of inventory.getItemDetail()
 ---@return TransferOrder[] transferOrders List of transfer orders
-local function getTransferOrders (origin, destination, missingPeriphs, filter)
+local function getTransferOrders (origin, destination, inventoryInfo, filter)
   local orders = {}
-
-  local inventoryInfo = ItemDetailAndLimitCache.new(missingPeriphs)
-  inventoryInfo:Fulfill({origin, destination})
 
   local possibleSlotsEmpty = inventoryInfo:GetEmptySlots(destination)
   local shouldTransfer = inventoryInfo:GetSlotsWithMatchingItems(origin, filter)

--- a/computercraft/sigils/pipeModes/spread.lua
+++ b/computercraft/sigils/pipeModes/spread.lua
@@ -34,14 +34,11 @@ end
 ---
 ---@param origin Group Origin group to transfer from
 ---@param destination Group Destination group to transfer to
----@param missingPeriphs table Set of missing peripherals by ID
+---@param inventoryInfo table Inventory detail and item limit cache
 ---@param filter function Filter function that accepts the result of inventory.getItemDetail()
 ---@return TransferOrder[] transferOrders List of transfer orders
-local function getTransferOrders (origin, destination, missingPeriphs, filter)
+local function getTransferOrders (origin, destination, inventoryInfo, filter)
   local orders = {}
-
-  local inventoryInfo = ItemDetailAndLimitCache.new(missingPeriphs)
-  inventoryInfo:Fulfill({origin, destination})
 
   for _, originSlot in pairs(inventoryInfo:GetSlotsWithMatchingItems(origin, filter)) do
     local originStack = inventoryInfo:GetItemDetail(originSlot)


### PR DESCRIPTION
I found that the last concurrency "fix" actually breaks if the factory has a lot of pipes and machines, which was no good. So I decided to test the code in this PR on one of my complicated Engimatica 6 Expert factories, and I have confirmed this runs properly.

Basically this PR makes the pipe runner fulfill all the item details for the slots of all groups affected by a batch of pipes that are being run together. Then the cache containing those item details are passed into the individual pipe's runner.

This contrasts with the previous behavior, in which each individual pipe runner created its own item detail cache that only fulfills its own origin/destination groups' slots.