### PR TITLE
allow pressing enter to submit session code

### DIFF
--- a/client/src/components/NewSessionModal.tsx
+++ b/client/src/components/NewSessionModal.tsx
@@ -41,6 +41,7 @@ export function NewSessionModal({ sendMessage, sessionId, setSessionId, addReqNe
                 type="text"
                 className="p-2.5 me-3 h-10 mcui-input grow"
                 onInput={ e => setSessionId((e.target as HTMLInputElement).value.toUpperCase()) }
+                onKeyDown={ e => { if (e.key === 'Enter') joinSession() } }
                 value={ sessionId }
               />
               <button


### PR DESCRIPTION
Closes #51 by allowing the user to press enter to submit the session code. When you press enter, it just runs the joinSession function.