### PR TITLE
More aggressive item detail optimization

### DIFF
--- a/computercraft/sigils/ItemDetailAndLimitCache.lua
+++ b/computercraft/sigils/ItemDetailAndLimitCache.lua
@@ -28,6 +28,7 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
 
   ---Fulfills the item details for each slot in the given groups in parallel
   ---@param groups Group[] List of groups to fulfill item limits and details for
+  ---@param forceDetail boolean True if item details should be requested even if cached
   function o:Fulfill(groups, forceDetail)
     local runner = Concurrent.default_runner
 
@@ -81,6 +82,8 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
   ---is needed is running the pipes, which are separated via the edge coloring
   ---algo.
   ---@param pipes Pipe[] Array of pipes whose origin/destinations groups should be fulfilled
+  ---@param groupMap table<string, Group> Maps Group IDs to Groups in the factory
+  ---@param forceDetail boolean True if item details should be requested even if cached
   function o:FulfillPipes (pipes, groupMap, forceDetail)
     local groups = {}
     for _, pipe in pairs(pipes) do

--- a/computercraft/sigils/ItemDetailAndLimitCache.lua
+++ b/computercraft/sigils/ItemDetailAndLimitCache.lua
@@ -60,6 +60,7 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
 
   ---Fulfills the item details for each slot in the given groups in parallel
   ---@param groups Group[] List of groups to fulfill item limits and details for
+  ---@param invLists table A map from peripheral names to non-detailed lists of items from Inventory.list()
   ---@param forceDetail boolean True if item details should be requested even if cached
   function o:Fulfill(groups, invLists, forceDetail)
     local runner = Concurrent.default_runner
@@ -88,7 +89,7 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
                     local getItemDetail = periph.getItemDetail or periph.getItemMeta
                     local itemDetail = getItemDetail(slot.slot)
                     o.map[slotId].itemDetail = itemDetail
-                    o.detailsByItemId[getFullItemId(item.name, item.nbt)] = itemDetail
+                    o.detailsByItemId[fullItemId] = itemDetail
                   end
                 end
               )

--- a/computercraft/sigils/ItemDetailAndLimitCache.lua
+++ b/computercraft/sigils/ItemDetailAndLimitCache.lua
@@ -61,8 +61,7 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
   ---Fulfills the item details for each slot in the given groups in parallel
   ---@param groups Group[] List of groups to fulfill item limits and details for
   ---@param invLists table A map from peripheral names to non-detailed lists of items from Inventory.list()
-  ---@param forceDetail boolean True if item details should be requested even if cached
-  function o:Fulfill(groups, invLists, forceDetail)
+  function o:Fulfill(groups, invLists)
     local runner = Concurrent.default_runner
 
     for _, group in pairs(groups) do
@@ -78,10 +77,12 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
           local item = invLists[slot.periphId][slot.slot]
           if item ~= nil then
             local fullItemId = getFullItemId(item.name, item.nbt)
+
+            -- retrieve cached itemDetail is possible
             if o.detailsByItemId[fullItemId] ~= nil then
               o.map[slotId].itemDetail = Utils.freezeTable(o.detailsByItemId[fullItemId])
               o.map[slotId].itemDetail.count = item.count
-            elseif (forceDetail or o.map[slotId].itemDetail == nil) then
+            else
               runner.spawn(
                 function ()
                   local periph = peripheral.wrap(slot.periphId)
@@ -128,8 +129,7 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
   ---algo.
   ---@param pipes Pipe[] Array of pipes whose origin/destinations groups should be fulfilled
   ---@param groupMap table<string, Group> Maps Group IDs to Groups in the factory
-  ---@param forceDetail boolean True if item details should be requested even if cached
-  function o:FulfillPipes (pipes, groupMap, forceDetail)
+  function o:FulfillPipes (pipes, groupMap)
     local groups = {}
     for _, pipe in pairs(pipes) do
       table.insert(groups, groupMap[pipe.from])
@@ -138,7 +138,7 @@ function ItemDetailAndLimitCache.new (missingPeriphs, initialMap)
 
     local invLists = o:FetchInvLists(groups)
 
-    o:Fulfill(groups, invLists, forceDetail)
+    o:Fulfill(groups, invLists)
   end
 
   ---Get the item limit of the given Slot

--- a/computercraft/sigils/pipe.lua
+++ b/computercraft/sigils/pipe.lua
@@ -92,7 +92,7 @@ local function processAllPipes (factory, inventoryInfo)
       end
     end
 
-    inventoryInfo:FulfillPipes(itemPipes, factory.groups, true)
+    inventoryInfo:FulfillPipes(itemPipes, factory.groups)
     parallel.waitForAll(unpack(pipeCoros))
   end
 end

--- a/computercraft/sigils/pipe.lua
+++ b/computercraft/sigils/pipe.lua
@@ -74,11 +74,10 @@ local function processPipe (pipe, groupMap, missingPeriphs)
   end
 end
 
-local function processAllPipes (factory)
+local function processAllPipes (factory, inventoryInfo)
   local batches = PipeBatcher.batchPipes(factory)
 
   for _, batchedPipeIds in pairs(batches) do
-    local inventoryInfo = ItemDetailAndLimitCache.new(factory.missing)
     local itemPipes = {}
     local pipeCoros = {}
 
@@ -93,14 +92,16 @@ local function processAllPipes (factory)
       end
     end
 
-    inventoryInfo:FulfillPipes(itemPipes, factory.groups)
+    inventoryInfo:FulfillPipes(itemPipes, factory.groups, true)
     parallel.waitForAll(unpack(pipeCoros))
   end
 end
 
 local function processAllPipesForever (factory)
+  local inventoryInfo = ItemDetailAndLimitCache.new(factory.missing)
+
   while true do
-    local ok, err = pcall(function () processAllPipes(factory) end)
+    local ok, err = pcall(function () processAllPipes(factory, inventoryInfo) end)
     if not ok then
       LOGGER:warn("pipe.lua#processAllPipesForever() caught error " .. err)
     end

--- a/computercraft/sigils/pipeModes/natural.lua
+++ b/computercraft/sigils/pipeModes/natural.lua
@@ -1,5 +1,4 @@
 local CacheMap = require('sigils.CacheMap')
-local ItemDetailAndLimitCache = require('sigils.ItemDetailAndLimitCache')
 local Utils = require('sigils.utils')
 
 ---An inventory slot on a peripheral in the network

--- a/computercraft/sigils/pipeModes/spread.lua
+++ b/computercraft/sigils/pipeModes/spread.lua
@@ -1,5 +1,3 @@
-local ItemDetailAndLimitCache = require('sigils.ItemDetailAndLimitCache')
-
 ---Get the amount of items from the origin item stack that can be moved to the
 ---destination item stack.
 ---@param originStack table ItemDetail of the origin item stack

--- a/computercraft/sigils/utils.lua
+++ b/computercraft/sigils/utils.lua
@@ -39,7 +39,7 @@ local function shallowCopy (tbl)
   return t2
 end
 
-function concatArrays (...)
+local function concatArrays (...)
   local arrays = {...} -- in some versions of CC, arg is overwritten by the program's args
   local t = {}
 
@@ -57,7 +57,7 @@ function concatArrays (...)
   return t
 end
 
-function freezeTable (tbl)
+local function freezeTable (tbl)
   return textutils.unserialize(textutils.serialize(tbl))
 end
 


### PR DESCRIPTION
This PR more aggressively caches itemDetails for items in the factory and is created to help with #49.

- When an `ItemDetailAndLimitCache` is created and the `FullfillPipes` function is run for the first time, it will request the non-detailed `list()` for each inventory peripheral in the groups connected to the pipes. 
- A cache maps from each [item ID+nbt hash] to their `itemDetail`, which are fulfilled in parallel jobs
- On subsequent runs, any [item ID+nbt hash] that has been seen before gets the `itemDetail` from the cache
- Any **new** [item ID+nbt hash] will have their `itemDetail` fulfilled in new parallel jobs, then stored in the cache